### PR TITLE
Fix compile errors in LORA_DEBUG_PRINT>0 and improve the framework.

### DIFF
--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -1132,6 +1132,10 @@ static bit_t decodeFrame (void) {
     u1_t hdr    = d[0];
     u1_t ftype  = hdr & HDR_FTYPE;
     int  dlen   = LMIC.dataLen;
+#if LMIC_DEBUG_LEVEL > 0
+    const char *window = (LMIC.txrxFlags & TXRX_DNW1) ? "RX1" : ((LMIC.txrxFlags & TXRX_DNW2) ? "RX2" : "Other");
+#endif
+
     if( dlen < OFF_DAT_OPTS+4 ||
         (hdr & HDR_MAJOR) != HDR_MAJOR_V1 ||
         (ftype != HDR_FTYPE_DADN  &&  ftype != HDR_FTYPE_DCDN) ) {
@@ -1142,8 +1146,7 @@ static bit_t decodeFrame (void) {
                             e_.info2  = hdr + (dlen<<8)));
       norx:
 #if LMIC_DEBUG_LEVEL > 0
-        const char *window = (LMIC.txrxFlags & TXRX_DNW1) ? "RX1" : ((LMIC.txrxFlags & TXRX_DNW2) ? "RX2" : "Other");
-        printf("%lu: Invalid downlink, window=%s\n", os_getTime(), window);
+        LMIC_DEBUG_PRINTF("%lu: Invalid downlink, window=%s\n", os_getTime(), window);
 #endif
         LMIC.dataLen = 0;
         return 0;
@@ -1426,7 +1429,7 @@ static bit_t decodeFrame (void) {
         LMIC.dataLen = pend-poff;
     }
 #if LMIC_DEBUG_LEVEL > 0
-    printf("%lu: Received downlink, window=%s, port=%d, ack=%d\n", os_getTime(), window, port, ackup);
+    LMIC_DEBUG_PRINTF("%lu: Received downlink, window=%s, port=%d, ack=%d\n", os_getTime(), window, port, ackup);
 #endif
     return 1;
 }
@@ -1595,7 +1598,7 @@ static bit_t processJoinAccept (void) {
             if( freq ) {
                 LMIC_setupChannel(chidx, freq, 0, -1);
 #if LMIC_DEBUG_LEVEL > 1
-                printf("%lu: Setup channel, idx=%d, freq=%lu\n", os_getTime(), chidx, (unsigned long)freq);
+                LMIC_DEBUG_PRINTF("%lu: Setup channel, idx=%d, freq=%lu\n", os_getTime(), chidx, (unsigned long)freq);
 #endif
             }
         }
@@ -2157,7 +2160,7 @@ static void startRxPing (xref2osjob_t osjob) {
 // Decide what to do next for the MAC layer of a device
 static void engineUpdate (void) {
 #if LMIC_DEBUG_LEVEL > 0
-    printf("%lu: engineUpdate, opmode=0x%x\n", os_getTime(), LMIC.opmode);
+    LMIC_DEBUG_PRINTF("%lu: engineUpdate, opmode=0x%x\n", os_getTime(), LMIC.opmode);
 #endif
     // Check for ongoing state: scan or TX/RX transaction
     if( (LMIC.opmode & (OP_SCAN|OP_TXRXPEND|OP_SHUTDOWN)) != 0 )

--- a/src/lmic/lmic.h
+++ b/src/lmic/lmic.h
@@ -34,6 +34,26 @@
 #include "oslmic.h"
 #include "lorabase.h"
 
+#if LMIC_DEBUG_LEVEL > 0
+# if defined(LMIC_DEBUG_INCLUDE)
+#   define LMIC_STRINGIFY_(x) #x
+#   define LMIC_STRINGIFY(x) LMIC_STRINGIFY_(x)
+#   include LMIC_STRINGIFY(LMIC_DEBUG_INCLUDE)
+# endif
+// if LMIC_DEBUG_PRINTF is now defined, just it. This lets you do anything
+// you like with a sufficiently crazy header file.
+# ifndef LMIC_DEBUG_PRINTF
+//  otherwise, check whether someone configured something to be used
+#   ifdef LMIC_DEBUG_PRINTF_FN
+#     define LMIC_DEBUG_PRINTF(f, ...) LMIC_DEBUG_PRINTF_FN(f, ## __VA_ARGS__)
+#   else // ndef LMIC_DEBUG_PRINTF_FN
+//    if there's other info, just use printf. In a pure Arduino environment,
+//    that's what will happen.
+#     define LMIC_DEBUG_PRINTF(f, ...) printf(f, ## __VA_ARGS__)
+#   endif // ndef LMIC_DEBUG_PRINTF_FN
+# endif // ndef LMIC_DEBUG_PRINTF
+#endif // LMIC_DEBUG_LEVEL > 0
+
 #ifdef __cplusplus
 extern "C"{
 #endif


### PR DESCRIPTION
Add LORA_DEBUG_INCLUDE to be used to inject an include file for
debugging. Add LORA_DEBUG_PRINTF_FN as a function name that
can be used with a simple wrapper to make LORA_DEBUG_PRINTF,
but allow the injected header file to override this behavior.