### PR TITLE
Add Catena 4551 hardware support.

### DIFF
--- a/src/hal/hal.cpp
+++ b/src/hal/hal.cpp
@@ -42,7 +42,7 @@ static void hal_io_init () {
     hal_interrupt_init();
 }
 
-// val == 1  => tx 1
+// val == LMIC_ANTENNA_SWITCH_TX  => tx
 void hal_pin_rxtx (u1_t val) {
     if (plmic_pins->rxtx != LMIC_UNUSED_PIN)
         digitalWrite(plmic_pins->rxtx, val);

--- a/src/lmic/config.h
+++ b/src/lmic/config.h
@@ -69,7 +69,21 @@
 // communicating with the radio.
 // The standard range is 125kHz-8MHz, but some boards can go faster.
 #ifndef LMIC_SPI_FREQ
-#define LMIC_SPI_FREQ 1E6
+# ifdef ARDUINO_CATENA_4550
+#  define LMIC_SPI_FREQ 4000000	/* 4MHz */
+# else
+#  define LMIC_SPI_FREQ 1E6
+# endif
+#endif
+
+// Change the TX/RX antenna polarity
+// By default, TX is 1 and RX is 0.
+#ifdef ARDUINO_CATENA_4550
+# define LMIC_ANTENNA_SWITCH_RX 1
+# define LMIC_ANTENNA_SWITCH_TX 0
+#else
+# define LMIC_ANTENNA_SWITCH_RX 0
+# define LMIC_ANTENNA_SWITCH_TX 1
 #endif
 
 // Set this to 1 to enable some basic debug output (using printf) about

--- a/src/lmic/radio.c
+++ b/src/lmic/radio.c
@@ -485,7 +485,7 @@ static void txfsk () {
     writeBuf(RegFifo, LMIC.frame, LMIC.dataLen);
 
     // enable antenna switch for TX
-    hal_pin_rxtx(1);
+    hal_pin_rxtx(LMIC_ANTENNA_SWITCH_TX);
 
     // now we actually start the transmission
     opmode(OPMODE_TX);
@@ -525,7 +525,7 @@ static void txlora () {
     writeBuf(RegFifo, LMIC.frame, LMIC.dataLen);
 
     // enable antenna switch for TX
-    hal_pin_rxtx(1);
+    hal_pin_rxtx(LMIC_ANTENNA_SWITCH_TX);
 
     // now we actually start the transmission
     opmode(OPMODE_TX);
@@ -607,7 +607,7 @@ static void rxlora (u1_t rxmode) {
     writeReg(LORARegIrqFlagsMask, ~TABLE_GET_U1(rxlorairqmask, rxmode));
 
     // enable antenna switch for RX
-    hal_pin_rxtx(0);
+    hal_pin_rxtx(LMIC_ANTENNA_SWITCH_RX);
 
     // now instruct the radio to receive
     if (rxmode == RXMODE_SINGLE) { // single rx
@@ -684,7 +684,7 @@ static void rxfsk (u1_t rxmode) {
     writeReg(RegDioMapping1, MAP_DIO0_FSK_READY|MAP_DIO1_FSK_NOP|MAP_DIO2_FSK_TIMEOUT);
 
     // enable antenna switch for RX
-    hal_pin_rxtx(0);
+    hal_pin_rxtx(LMIC_ANTENNA_SWITCH_RX);
 
     // now instruct the radio to receive
     hal_waitUntil(LMIC.rxtime); // busy wait until exact rx time


### PR DESCRIPTION
Add support for Catena 4551 hardware.  This board uses the Murata module, which requires that we do a few extra things for controlling the antenna, etc.
