### PR TITLE
Another as923jp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,6 @@ install:
 
 script:
  - arduino --verify --board mcci:samd:mcci_catena_4450 $PWD/examples/raw-feather/raw-feather.ino
- - printf '#define COMPILE_REGRESSION_TEST 1\n#define CFG_SX1276_RADIO 1\n#define CFG_us915 1\n' > $PWD/project_config/lmic_project_config.h && arduino --verify --board mcci:samd:mcci_catena_4450 $PWD/examples/ttn-otaa-feather-us915/ttn-otaa-feather-us915.ino
+ - printf '#define COMPILE_REGRESSION_TEST 1\n#define CFG_sx1276_radio 1\n#define CFG_us915 1\n' > $PWD/project_config/lmic_project_config.h && arduino --verify --board mcci:samd:mcci_catena_4450 $PWD/examples/ttn-otaa-feather-us915/ttn-otaa-feather-us915.ino
 
 # - arduino --pref "build.verbose=true" --verify --board mcci:stm32:Catena:pnum=CATENA_4551 $PWD/examples/raw-feather/raw-feather.ino

--- a/src/hal/hal.cpp
+++ b/src/hal/hal.cpp
@@ -61,6 +61,10 @@ void hal_pin_rst (u1_t val) {
     }
 }
 
+s1_t hal_getRssiCal (void) {
+    return plmic_pins->rssi_cal;
+}
+
 #if !defined(LMIC_USE_INTERRUPTS)
 static void hal_interrupt_init() {
     pinMode(plmic_pins->dio[0], INPUT);

--- a/src/hal/hal.h
+++ b/src/hal/hal.h
@@ -18,6 +18,9 @@ struct lmic_pinmap {
     u1_t rst;
     u1_t dio[NUM_DIO];
     u1_t rxtx_rx_active;
+    s1_t rssi_cal;              // byte 7: cal in dB -- added to RSSI
+                                //   measured prior to decision.
+                                //   Must include noise guardband!
     u4_t spi_freq;
 };
 

--- a/src/lmic/config.h
+++ b/src/lmic/config.h
@@ -35,6 +35,15 @@
 # error The selected CFG_... region is not supported yet.
 #endif
 
+#ifndef LMIC_COUNTRY_CODE
+# define LMIC_COUNTRY_CODE      LMIC_COUNTRY_CODE_NONE
+#endif
+
+// if the country code is japan, then the region must be AS923
+#if LMIC_COUNTRY_CODE == LMIC_COUNTRY_CODE_JP && CFG_region != LMIC_REGION_as923
+# error "If country code is JP, then region must be AS923"
+#endif
+
 #if !(CFG_LMIC_EU_like || CFG_LMIC_US_like)
 # error "Internal error: Neither EU-like nor US-like!"
 #endif

--- a/src/lmic/hal.h
+++ b/src/lmic/hal.h
@@ -105,6 +105,11 @@ u1_t hal_checkTimer (u4_t targettime);
  */
 void hal_failed (const char *file, u2_t line);
 
+/*
+ * get the calibration value for radio_rssi
+ */
+s1_t hal_getRssiCal (void);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -971,6 +971,7 @@ static void schedRx12 (ostime_t delay, osjobcb_t func, u1_t dr) {
     // (again note that hsym is half a sumbol time, so no /2 needed)
     LMIC.rxtime = LMIC.txend + delay + PAMBL_SYMS * hsym - LMIC.rxsyms * hsym;
 
+    LMIC_X_DEBUG_PRINTF("%lu: sched Rx12 %lu\n", os_getTime(), LMIC.rxtime - RX_RAMPUP);
     os_setTimedCallback(&LMIC.osjob, LMIC.rxtime - RX_RAMPUP, func);
 }
 
@@ -1129,6 +1130,7 @@ static bit_t processJoinAccept (void) {
 
 
 static void processRx2Jacc (xref2osjob_t osjob) {
+    LMIC_X_DEBUG_PRINTF("%lu: Jacc Rx2\n", os_getTime());
     if( LMIC.dataLen == 0 ) {
         initTxrxFlags(__func__, 0);  // nothing in 1st/2nd DN slot
     }
@@ -1143,6 +1145,7 @@ static void setupRx2Jacc (xref2osjob_t osjob) {
 
 
 static void processRx1Jacc (xref2osjob_t osjob) {
+    LMIC_X_DEBUG_PRINTF("%lu: Jacc Rx1\n", os_getTime());
     if( LMIC.dataLen == 0 || !processJoinAccept() )
         schedRx12(DELAY_JACC2_osticks, FUNC_ADDR(setupRx2Jacc), LMIC.dn2Dr);
 }

--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -1130,7 +1130,6 @@ static bit_t processJoinAccept (void) {
 
 
 static void processRx2Jacc (xref2osjob_t osjob) {
-    LMIC_X_DEBUG_PRINTF("%lu: Jacc Rx2\n", os_getTime());
     if( LMIC.dataLen == 0 ) {
         initTxrxFlags(__func__, 0);  // nothing in 1st/2nd DN slot
     }
@@ -1145,7 +1144,6 @@ static void setupRx2Jacc (xref2osjob_t osjob) {
 
 
 static void processRx1Jacc (xref2osjob_t osjob) {
-    LMIC_X_DEBUG_PRINTF("%lu: Jacc Rx1\n", os_getTime());
     if( LMIC.dataLen == 0 || !processJoinAccept() )
         schedRx12(DELAY_JACC2_osticks, FUNC_ADDR(setupRx2Jacc), LMIC.dn2Dr);
 }
@@ -1816,6 +1814,7 @@ static void engineUpdate (void) {
                        e_.eui    = MAIN::CDEV->getEui(),
                        e_.info   = osticks2ms(txbeg-now),
                        e_.info2  = LMIC.seqnoUp-1));
+    LMIC_X_DEBUG_PRINTF("%lu: next engine update in %lu\n", now, txbeg-TX_RAMPUP);
     os_setTimedCallback(&LMIC.osjob, txbeg-TX_RAMPUP, FUNC_ADDR(runEngineUpdate));
 }
 

--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -615,15 +615,20 @@ scan_mac_cmds(
         case MCMD_DN2P_SET: {
 #if !defined(DISABLE_MCMD_DN2P_SET)
             dr_t dr = (dr_t)(opts[oidx+1] & 0x0F);
+            u1_t rx1DrOffset = (u1_t)((opts[oidx+1] & 0x70) >> 4);
             u4_t freq = LMICbandplan_convFreq(&opts[oidx+2]);
             LMIC.dn2Ans = 0x80;   // answer pending
             if( validDR(dr) )
                 LMIC.dn2Ans |= MCMD_DN2P_ANS_DRACK;
             if( freq != 0 )
                 LMIC.dn2Ans |= MCMD_DN2P_ANS_CHACK;
-            if( LMIC.dn2Ans == (0x80|MCMD_DN2P_ANS_DRACK|MCMD_DN2P_ANS_CHACK) ) {
+            if (rx1DrOffset <= 3)
+                LMIC.dn2Ans |= MCMD_DN2P_ANS_RX1DrOffsetAck;
+
+            if( LMIC.dn2Ans == (0x80|MCMD_DN2P_ANS_DRACK|MCMD_DN2P_ANS_CHACK| MCMD_DN2P_ANS_RX1DrOffsetAck) ) {
                 LMIC.dn2Dr = dr;
                 LMIC.dn2Freq = freq;
+                LMIC.rx1DrOffset = rx1DrOffset;
                 DO_DEVDB(LMIC.dn2Dr,dn2Dr);
                 DO_DEVDB(LMIC.dn2Freq,dn2Freq);
             }
@@ -1866,6 +1871,7 @@ void LMIC_reset (void) {
 
 void LMIC_init (void) {
     LMIC.opmode = OP_SHUTDOWN;
+    LMICbandplan_init();
 }
 
 

--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -1711,7 +1711,7 @@ static void engineUpdate (void) {
         // Earliest possible time vs overhead to setup radio
         if( txbeg - (now + TX_RAMPUP) < 0 ) {
             // We could send right now!
-        txbeg = now;
+            txbeg = now;
             dr_t txdr = (dr_t)LMIC.datarate;
 #if !defined(DISABLE_JOIN)
             if( jacc ) {

--- a/src/lmic/lmic.h
+++ b/src/lmic/lmic.h
@@ -70,6 +70,17 @@
 # define LMIC_DEBUG_FLUSH()             do { ; } while (0)
 #endif // LMIC_DEBUG_LEVEL == 0
 
+#if LMIC_X_DEBUG_LEVEL > 0
+#  ifdef LMIC_DEBUG_PRINTF_FN
+     extern void LMIC_DEBUG_PRINTF_FN(const char *f, ...);
+#    define LMIC_X_DEBUG_PRINTF(f, ...) LMIC_DEBUG_PRINTF_FN(f, ## __VA_ARGS__)
+#  else
+#    error "LMIC_DEBUG_PRINTF_FN must be defined."
+#  endif
+#else
+#  define LMIC_X_DEBUG_PRINTF(f, ...)  do {;} while(0)
+#endif
+
 #ifdef __cplusplus
 extern "C"{
 #endif

--- a/src/lmic/lmic.h
+++ b/src/lmic/lmic.h
@@ -207,6 +207,11 @@ struct lmic_t {
     // Radio settings TX/RX (also accessed by HAL)
     ostime_t    txend;
     ostime_t    rxtime;
+
+    // LBT info
+    ostime_t    lbt_ticks;      // ticks to listen
+    s1_t        lbt_dbmax;      // max permissible dB on our channle (eg -80) 
+
     u4_t        freq;
     s1_t        rssi;
     s1_t        snr;

--- a/src/lmic/lmic.h
+++ b/src/lmic/lmic.h
@@ -74,11 +74,13 @@
 #  ifdef LMIC_DEBUG_PRINTF_FN
      extern void LMIC_DEBUG_PRINTF_FN(const char *f, ...);
 #    define LMIC_X_DEBUG_PRINTF(f, ...) LMIC_DEBUG_PRINTF_FN(f, ## __VA_ARGS__)
+#    define LMIC_X_DEBUG_PRINTS(s) Serial.println(F(s))
 #  else
 #    error "LMIC_DEBUG_PRINTF_FN must be defined."
 #  endif
 #else
 #  define LMIC_X_DEBUG_PRINTF(f, ...)  do {;} while(0)
+#  define LMIC_X_DEBUG_PRINTS(s) do {;} while(0)
 #endif
 
 #ifdef __cplusplus

--- a/src/lmic/lmic.h
+++ b/src/lmic/lmic.h
@@ -74,13 +74,11 @@
 #  ifdef LMIC_DEBUG_PRINTF_FN
      extern void LMIC_DEBUG_PRINTF_FN(const char *f, ...);
 #    define LMIC_X_DEBUG_PRINTF(f, ...) LMIC_DEBUG_PRINTF_FN(f, ## __VA_ARGS__)
-#    define LMIC_X_DEBUG_PRINTS(s) Serial.println(F(s))
 #  else
 #    error "LMIC_DEBUG_PRINTF_FN must be defined."
 #  endif
 #else
 #  define LMIC_X_DEBUG_PRINTF(f, ...)  do {;} while(0)
-#  define LMIC_X_DEBUG_PRINTS(s) do {;} while(0)
 #endif
 
 #ifdef __cplusplus

--- a/src/lmic/lmic_as923.c
+++ b/src/lmic/lmic_as923.c
@@ -350,7 +350,7 @@ LMICas923_updateTx(ostime_t txbeg) {
         // Update channel/global duty cycle stats
         xref2band_t band = &LMIC.bands[freq & 0x3];
         LMIC.freq = freq & ~(u4_t)3;
-        LMIC.txpow = band->txpow + LMICas923_getMaxEIRP(LMIC.txParam);
+        LMIC.txpow = LMICas923_getMaxEIRP(LMIC.txParam);
         band->avail = txbeg + airtime * band->txcap;
         if (LMIC.globalDutyRate != 0)
                 LMIC.globalDutyAvail = txbeg + (airtime << LMIC.globalDutyRate);

--- a/src/lmic/lmic_as923.c
+++ b/src/lmic/lmic_as923.c
@@ -174,8 +174,7 @@ void LMICas923_initDefaultChannels(bit_t join) {
                 LMIC.channelDrMap[fu] = DR_RANGE_MAP(AS923_DR_SF12, AS923_DR_SF7B);
         }
 
-	// all channels face a 1% duty cycle.
-        LMIC.bands[BAND_CENTI].txcap = 100;   // 1%
+        LMIC.bands[BAND_CENTI].txcap = AS923_TX_CAP;
         LMIC.bands[BAND_CENTI].txpow = AS923_TX_EIRP_MAX_DBM;
         LMIC.bands[BAND_CENTI].lastchnl = os_getRndU1() % MAX_CHANNELS;
         LMIC.bands[BAND_CENTI].avail = os_getTime();

--- a/src/lmic/lmic_as923.c
+++ b/src/lmic/lmic_as923.c
@@ -181,6 +181,25 @@ void LMICas923_initDefaultChannels(bit_t join) {
         LMIC.bands[BAND_CENTI].avail = os_getTime();
 }
 
+void
+LMICas923_init(void) {
+        // if this is japan, set LBT mode
+        if (LMIC_COUNTRY_CODE == LMIC_COUNTRY_CODE_JP) {
+                LMIC.lbt_ticks = us2osticks(AS923JP_LBT_US);
+                LMIC.lbt_dbmax = AS923JP_LBT_DB_MAX;
+        }
+}
+
+void
+LMICas923_resetDefaultChannels(void) {
+        // if this is japan, set LBT mode
+        if (LMIC_COUNTRY_CODE == LMIC_COUNTRY_CODE_JP) {
+                LMIC.lbt_ticks = us2osticks(AS923JP_LBT_US);
+                LMIC.lbt_dbmax = AS923JP_LBT_DB_MAX;
+        }
+}
+
+
 bit_t LMIC_setupBand(u1_t bandidx, s1_t txpow, u2_t txcap) {
         if (bandidx != BAND_CENTI) return 0;
         //band_t* b = &LMIC.bands[bandidx];

--- a/src/lmic/lmic_as923.c
+++ b/src/lmic/lmic_as923.c
@@ -185,7 +185,7 @@ void
 LMICas923_init(void) {
         // if this is japan, set LBT mode
         if (LMIC_COUNTRY_CODE == LMIC_COUNTRY_CODE_JP) {
-                LMIC.lbt_ticks = us2osticks(AS923JP_LBT_US);
+                LMIC.lbt_ticks = ms2osticks(AS923JP_LBT_5MS);
                 LMIC.lbt_dbmax = AS923JP_LBT_DB_MAX;
         }
 }
@@ -194,7 +194,7 @@ void
 LMICas923_resetDefaultChannels(void) {
         // if this is japan, set LBT mode
         if (LMIC_COUNTRY_CODE == LMIC_COUNTRY_CODE_JP) {
-                LMIC.lbt_ticks = us2osticks(AS923JP_LBT_US);
+                LMIC.lbt_ticks = ms2osticks(AS923JP_LBT_5MS);
                 LMIC.lbt_dbmax = AS923JP_LBT_DB_MAX;
         }
 }

--- a/src/lmic/lmic_bandplan.h
+++ b/src/lmic/lmic_bandplan.h
@@ -140,6 +140,9 @@
 # error "LMICbandplan_nextJoinTime() not defined by bandplan"
 #endif
 
+#if !defined(LMICbandplan_init)
+# error "LMICbandplan_init() not defined by bandplan"
+#endif
 //
 // Things common to lmic.c code
 //

--- a/src/lmic/lmic_bandplan_as923.h
+++ b/src/lmic/lmic_bandplan_as923.h
@@ -52,6 +52,22 @@ LMICas923_isValidBeacon1(const uint8_t *d) {
 #undef LMICbandplan_isValidBeacon1
 #define LMICbandplan_isValidBeacon1(pFrame) LMICas923_isValidBeacon1(pFrame)
 
+// override default for LMICbandplan_resetDefaultChannels
+void
+LMICas923_resetDefaultChannels(void);
+
+#undef LMICbandplan_resetDefaultChannels
+#define LMICbandplan_resetDefaultChannels()     \
+        LMICas923_resetDefaultChannels()
+
+// override default for LMICbandplan_init
+void LMICas923_init(void);
+
+#undef LMICbandplan_init
+#define LMICbandplan_init()     \
+        LMICas923_init()
+
+
 // override default for LMICbandplan_isFSK()
 #undef LMICbandplan_isFSK
 #define LMICbandplan_isFSK()    (/* TX datarate */LMIC.rxsyms == AS923_DR_FSK)

--- a/src/lmic/lmic_config_preconditions.h
+++ b/src/lmic/lmic_config_preconditions.h
@@ -72,6 +72,16 @@ Revision history:
 #define LMIC_REGION_kr921    8
 #define LMIC_REGION_in866    9
 
+// country codes for comparison. These values are chosen from the 2-letter domain suffixes (which
+// I think are ISO standardized)
+#define LMIC_COUNTRY_CODE_C(c1, c2)     ((c1) * 256 + (c2))
+
+// this special code means "no country code defined"
+#define LMIC_COUNTRY_CODE_NONE  0
+
+// specific countries. Only the ones that are known in the code are defined.
+#define LMIC_COUNTRY_CODE_JP    LMIC_COUNTRY_CODE_C('j', 'p')
+
 // include the file that the user is really supposed to edit. But for really strange
 // ports, this can be suppressed
 #ifndef ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS

--- a/src/lmic/lmic_eu_like.c
+++ b/src/lmic/lmic_eu_like.c
@@ -103,7 +103,15 @@ ostime_t LMICeulike_nextJoinState(uint8_t nDefaultChannels) {
                 if (LMIC.datarate == LORAWAN_DR0)
                         failed = 1; // we have tried all DR - signal EV_JOIN_FAILED
                 else
+                {
+#if CFG_region != LMIC_REGION_as923
                         LMICcore_setDrJoin(DRCHG_NOJACC, decDR((dr_t)LMIC.datarate));
+#else
+                        // in the join of AS923 v1.1 or older, only DR2 is used.
+                        // no need to change the DR.
+                        LMIC.datarate = AS923_DR_SF10;
+#endif
+                }
         }
         // Clear NEXTCHNL because join state engine controls channel hopping
         LMIC.opmode &= ~OP_NEXTCHNL;

--- a/src/lmic/lmic_eu_like.h
+++ b/src/lmic/lmic_eu_like.h
@@ -92,4 +92,7 @@ static inline ostime_t LMICeulike_nextJoinTime(ostime_t now) {
 }
 #define LMICbandplan_nextJoinTime(now)     LMICeulike_nextJoinTime(now)
 
+#define LMICbandplan_init()     \
+        do { /* nothing */ } while (0)
+
 #endif // _lmic_eu_like_h_

--- a/src/lmic/lorabase.h
+++ b/src/lmic/lorabase.h
@@ -483,7 +483,8 @@ enum {
     MCMD_LADR_ANS_CHACK  = 0x01, // 0=unknown channel enabled
 };
 enum {
-    MCMD_DN2P_ANS_RFU    = 0xFC, // RFU bits
+    MCMD_DN2P_ANS_RFU    = 0xF8, // RFU bits
+    MCMD_DN2P_ANS_RX1DrOffsetAck = 0x04, // 0=dr2 not allowed
     MCMD_DN2P_ANS_DRACK  = 0x02, // 0=unknown data rate
     MCMD_DN2P_ANS_CHACK  = 0x01, // 0=unknown channel enabled
 };

--- a/src/lmic/lorabase_as923.h
+++ b/src/lmic/lorabase_as923.h
@@ -74,7 +74,7 @@ enum { DR_PAGE_AS923 = 0x10 * (LMIC_REGION_as923 - 1) };
 
 enum { AS923_LMIC_REGION_EIRP = 1 };         // region uses EIRP
 
-enum { AS923JP_LBT_US = 125 };          // microseconds of LBT time
+enum { AS923JP_LBT_5MS = 5 };          // microseconds of LBT time
 enum { AS923JP_LBT_DB_MAX = -80 };      // maximum channel strength
 
 #endif /* _lorabase_as923_h_ */

--- a/src/lmic/lorabase_as923.h
+++ b/src/lmic/lorabase_as923.h
@@ -77,4 +77,9 @@ enum { AS923_LMIC_REGION_EIRP = 1 };         // region uses EIRP
 enum { AS923JP_LBT_5MS = 5 };          // microseconds of LBT time
 enum { AS923JP_LBT_DB_MAX = -80 };      // maximum channel strength
 
+#if !defined(AS923_TX_CAP)
+// AS923 v1.1, all channels face a 1% duty cycle.
+# define AS923_TX_CAP 100
+#endif
+
 #endif /* _lorabase_as923_h_ */

--- a/src/lmic/lorabase_as923.h
+++ b/src/lmic/lorabase_as923.h
@@ -74,4 +74,7 @@ enum { DR_PAGE_AS923 = 0x10 * (LMIC_REGION_as923 - 1) };
 
 enum { AS923_LMIC_REGION_EIRP = 1 };         // region uses EIRP
 
+enum { AS923JP_LBT_US = 125 };          // microseconds of LBT time
+enum { AS923JP_LBT_DB_MAX = -80 };      // maximum channel strength
+
 #endif /* _lorabase_as923_h_ */

--- a/src/lmic/oslmic.h
+++ b/src/lmic/oslmic.h
@@ -73,6 +73,8 @@ typedef   struct rxsched_t rxsched_t;
 typedef   struct bcninfo_t bcninfo_t;
 typedef        const u1_t* xref2cu1_t;
 typedef              u1_t* xref2u1_t;
+typedef              s4_t  ostime_t;
+
 #define TYPEDEF_xref2rps_t     typedef         rps_t* xref2rps_t
 #define TYPEDEF_xref2rxsched_t typedef     rxsched_t* xref2rxsched_t
 #define TYPEDEF_xref2chnldef_t typedef     chnldef_t* xref2chnldef_t
@@ -96,6 +98,15 @@ u1_t radio_rand1 (void);
 #define DEFINE_LMIC  struct lmic_t LMIC
 #define DECLARE_LMIC extern struct lmic_t LMIC
 
+typedef struct oslmic_radio_rssi_s oslmic_radio_rssi_t;
+
+struct oslmic_radio_rssi_s {
+        s2_t    min_rssi;
+        s2_t    max_rssi;
+        s2_t    mean_rssi;
+        u2_t    n_rssi;
+};
+
 int radio_init (void);
 void radio_irq_handler (u1_t dio);
 void os_init (void);
@@ -103,6 +114,7 @@ int os_init_ex (const void *pPinMap);
 void os_runloop (void);
 void os_runloop_once (void);
 u1_t radio_rssi (void);
+void radio_monitor_rssi(ostime_t n, oslmic_radio_rssi_t *pRssi);
 
 //================================================================================
 
@@ -119,8 +131,6 @@ u1_t radio_rssi (void);
 #elif OSTICKS_PER_SEC < 10000 || OSTICKS_PER_SEC > 64516
 #error Illegal OSTICKS_PER_SEC - must be in range [10000:64516]. One tick must be 15.5us .. 100us long.
 #endif
-
-typedef s4_t  ostime_t;
 
 #if !HAS_ostick_conv
 #define us2osticks(us)   ((ostime_t)( ((int64_t)(us) * OSTICKS_PER_SEC) / 1000000))

--- a/src/lmic/radio.c
+++ b/src/lmic/radio.c
@@ -195,7 +195,17 @@
 #define RXLORA_RXMODE_RSSI_REG_MODEM_CONFIG2 0x74
 #endif
 
+//-----------------------------------------
+// Parameters for RSSI monitoring
+#define SX127X_FREQ_LF_MAX      525000000       // per datasheet 6.3
+ 
+// per datasheet 5.5.3:
+#define SX127X_RSSI_ADJUST_LF   -164            // add to rssi value to get dB (LF)
+#define SX127X_RSSI_ADJUST_HF   -157            // add to rssi value to get dB (HF)
 
+// per datasheet 2.5.2 (but note that we ought to ask Semtech to confirm, because
+// datasheet is unclear).
+#define SX127X_RX_POWER_UP      us2osticks(500) // delay this long to let the receiver power up.
 
 // ----------------------------------------
 // Constants for radio registers
@@ -549,7 +559,27 @@ static void txlora () {
 
 // start transmitter (buf=LMIC.frame, len=LMIC.dataLen)
 static void starttx () {
-    ASSERT( (readReg(RegOpMode) & OPMODE_MASK) == OPMODE_SLEEP );
+    u1_t const rOpMode = readReg(RegOpMode);
+
+    // originally, this code ASSERT()ed, but asserts are both bad and
+    // blunt instruments. If we see that we're not in sleep mode, 
+    // force sleep (because we might have to switch modes)
+    if ((rOpMode & OPMODE_MASK) != OPMODE_SLEEP) {
+        opmode(OPMODE_SLEEP);
+        hal_waitUntil(os_getTime() + ms2osticks(1));
+    }
+
+    if (LMIC.lbt_ticks > 0) {
+        oslmic_radio_rssi_t rssi;
+        radio_monitor_rssi(LMIC.lbt_ticks, &rssi);
+
+        if (rssi.max_rssi >= LMIC.lbt_dbmax) {
+        // complete the request by scheduling the job
+        os_setCallback(&LMIC.osjob, LMIC.osjob.func);
+        return;
+        }
+    }
+
     if(getSf(LMIC.rps) == FSK) { // FSK modem
         txfsk();
     } else { // LoRa modem
@@ -789,6 +819,70 @@ u1_t radio_rssi () {
     u1_t r = readReg(LORARegRssiValue);
     hal_enableIRQs();
     return r;
+}
+
+// monitor rssi for specified number of ostime_t ticks, and return statistics
+// This puts the radio into RX continuous mode, waits long enough for the
+// oscillators to start and the PLL to lock, and then measures for the specified
+// period of time.  The radio is then returned to idle.
+//
+// RSSI returned is expressed in units of dB, and is offset according to the
+// current radio setting per section 5.5.5 of Semtech 1276 datasheet.
+void radio_monitor_rssi(ostime_t nTicks, oslmic_radio_rssi_t *pRssi) {
+    uint8_t rssiMax, rssiMin;
+    uint16_t rssiSum;
+    uint16_t rssiN;
+
+    int rssiAdjust;
+    ostime_t tBegin;
+    int notDone;
+
+    rxlora(RXMODE_SCAN);
+
+    // while we're waiting for the PLLs to spin up, determine which
+    // band we're in and choose the base RSSI.
+    if (LMIC.freq > SX127X_FREQ_LF_MAX) {
+            rssiAdjust = SX127X_RSSI_ADJUST_HF;
+    } else {
+            rssiAdjust = SX127X_RSSI_ADJUST_LF;
+    }
+    rssiAdjust += hal_getRssiCal();
+
+    // zero the results
+    rssiMax = 255;
+    rssiMin = 0;
+    rssiSum = 0;
+    rssiN = 0;
+
+    // wait for PLLs
+    hal_waitUntil(os_getTime() + SX127X_RX_POWER_UP);
+
+    // scan for the desired time.
+    tBegin = os_getTime();
+    rssiMax = 0;
+    do {
+        ostime_t now;
+
+        u1_t rssiNow = readReg(LORARegRssiValue);
+
+        if (rssiMax < rssiNow)
+                rssiMax = rssiNow;
+        if (rssiNow < rssiMin)
+                rssiMin = rssiNow;
+        rssiSum += rssiNow;
+        ++rssiN;
+        now = os_getTime();
+        notDone = now - (tBegin + nTicks) < 0;
+    } while (notDone);
+
+    // put radio back to sleep
+    opmode(OPMODE_SLEEP);
+
+    // compute the results
+    pRssi->max_rssi = (s2_t) (rssiMax + rssiAdjust);
+    pRssi->min_rssi = (s2_t) (rssiMin + rssiAdjust);
+    pRssi->mean_rssi = (s2_t) (rssiAdjust + ((rssiSum + (rssiN >> 1)) / rssiN));
+    pRssi->n_rssi = rssiN;
 }
 
 static CONST_TABLE(u2_t, LORA_RXDONE_FIXUP)[] = {

--- a/src/lmic/radio.c
+++ b/src/lmic/radio.c
@@ -557,6 +557,8 @@ static void txlora () {
 #endif
 }
 
+static oslmic_radio_rssi_t xRssi;
+
 // start transmitter (buf=LMIC.frame, len=LMIC.dataLen)
 static void starttx () {
     u1_t const rOpMode = readReg(RegOpMode);
@@ -570,13 +572,12 @@ static void starttx () {
     }
 
     if (LMIC.lbt_ticks > 0) {
-        oslmic_radio_rssi_t rssi;
-        radio_monitor_rssi(LMIC.lbt_ticks, &rssi);
+        radio_monitor_rssi(LMIC.lbt_ticks, &xRssi);
 
-        if (rssi.max_rssi >= LMIC.lbt_dbmax) {
-        // complete the request by scheduling the job
-        os_setCallback(&LMIC.osjob, LMIC.osjob.func);
-        return;
+        if (xRssi.max_rssi >= LMIC.lbt_dbmax) {
+            // complete the request by scheduling the job
+            os_setCallback(&LMIC.osjob, LMIC.osjob.func);
+            return;
         }
     }
 

--- a/src/lmic/radio.c
+++ b/src/lmic/radio.c
@@ -885,9 +885,6 @@ void radio_monitor_rssi(ostime_t nTicks, oslmic_radio_rssi_t *pRssi) {
         now = os_getTime();
         hal_disableIRQs(); //xxx
         notDone = now - (tBegin + nTicks) < 0;
-#if LMIC_X_DEBUG_LEVEL > 0
-	LMIC_X_DEBUG_PRINTF("notDone:%d\n", notDone); //xxx
-#endif
         if (sentry++ > 20) //xxx
             break; //xxx
     } while (notDone);

--- a/src/lmic/radio.c
+++ b/src/lmic/radio.c
@@ -577,7 +577,7 @@ static void starttx () {
         oslmic_radio_rssi_t rssi;
         radio_monitor_rssi(LMIC.lbt_ticks, &rssi);
 #if LMIC_X_DEBUG_LEVEL > 0
-	LMIC_X_DEBUG_PRINTF("rssi max:min=%d:%d %d times in %d\n", rssi.max_rssi, rssi.min_rssi, rssi.n_rssi, LMIC.lbt_ticks);
+	LMIC_X_DEBUG_PRINTF("LBT rssi max:min=%d:%d %d times in %d\n", rssi.max_rssi, rssi.min_rssi, rssi.n_rssi, LMIC.lbt_ticks);
 #endif
 
         if (rssi.max_rssi >= LMIC.lbt_dbmax) {
@@ -936,6 +936,7 @@ void radio_irq_handler (u1_t dio) {
 #endif
     if( (readReg(RegOpMode) & OPMODE_LORA) != 0) { // LORA modem
         u1_t flags = readReg(LORARegIrqFlags);
+        LMIC_X_DEBUG_PRINTF("IRQ=%02x\n", flags);
         if( flags & IRQ_LORA_TXDONE_MASK ) {
             // save exact tx time
             LMIC.txend = now - us2osticks(43); // TXDONE FIXUP
@@ -954,7 +955,9 @@ void radio_irq_handler (u1_t dio) {
             readBuf(RegFifo, LMIC.frame, LMIC.dataLen);
             // read rx quality parameters
             LMIC.snr  = readReg(LORARegPktSnrValue); // SNR [dB] * 4
-            LMIC.rssi = readReg(LORARegPktRssiValue) - 125 + 64; // RSSI [dBm] (-196...+63)
+            LMIC.rssi = readReg(LORARegPktRssiValue);
+            LMIC_X_DEBUG_PRINTF("RX snr=%u rssi=%d\n", LMIC.snr/4, SX127X_RSSI_ADJUST_HF + LMIC.rssi);
+            LMIC.rssi = LMIC.rssi - 125 + 64; // RSSI [dBm] (-196...+63)
         } else if( flags & IRQ_LORA_RXTOUT_MASK ) {
             // indicate timeout
             LMIC.dataLen = 0;


### PR DESCRIPTION
Hi,

Thanks for providing a great code.  It's wonderful and helpful very much to use arduino-based LoRaWAN module.

When I started to run Dragino with LMiC in Japan, I noticed that there were some missing feature and some non-conforming staff in LMiC.

I forked from mater and merged TMM-feature-as923jp, (which is not there, I don't why).  Then, I fixed LBT, txpower, and debug messages.

My modifications are mixed.  It should be separated to be easy to merge for you.  However, the time is moving.  I have decided to submit a pull request before the diff will be increased.

Please any suggestions if you would like to merge this and tell me how I should do.

Thanks,
Shoichi