### PR TITLE
Fix #92: support v1.1.0 MCCI STM32 BSP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_install:
 install:
  - arduino --install-boards mcci:samd
  - arduino --install-boards mcci:stm32
- - 'if [ -d $HOME/.arduino15/packages/mcci/hardawre/stm32/1.1.0 ]; then echo "Work around broken BSP version 1.1.0" ; export MCCI_STM32_OPTS="$MCCI_STM32_OPTS --pref build.board=CATENA_4551" ; fi'
+ - 'if [ -d $HOME/.arduino15/packages/mcci/hardware/stm32/1.1.0 ]; then echo "Work around broken BSP version 1.1.0" ; export MCCI_STM32_OPTS="$MCCI_STM32_OPTS --pref build.board=CATENA_4551" ; fi'
 
 script:
 


### PR DESCRIPTION
Switch to new commands for the updated BSP, and work around bug https://github.com/mcci-catena/Arduino_Core_STM32/issues/31.