### PR TITLE
Fix coding of the "Margin" field of the "DevStatusAns" command payload

### DIFF
--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -4,7 +4,7 @@
  *
  * Copyright (c) 2016-2018 MCCI Corporation.
  * All rights reserved.
- *
+ * 
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
  *  * Redistributions of source code must retain the above copyright
@@ -840,7 +840,7 @@ static bit_t decodeFrame (void) {
 
     // Process OPTS
     int m = LMIC.rssi - RSSI_OFF - getSensitivity(LMIC.rps);
-    LMIC.margin = m < 0 ? 0 : m > 31 ? 31 : m;
+    LMIC.margin = m < 0 ? 0 : m > 254 ? 254 : m;
 
 #if LMIC_DEBUG_LEVEL > 0
     LMIC_DEBUG_PRINTF("%lu: process options (olen=%#x)\n", os_getTime(), olen);

--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -612,7 +612,7 @@ scan_mac_cmds(
             // LMIC.snr is SNR time 4, convert to real SNR; rounding towards zero.
             const int snr = (LMIC.snr + 2) / 4;
             // per [1.02] 5.5. the margin is the SNR.
-            LMIC.devsAnsMargin = (u1_t)(0b00111111 & (snr <= -32 ? -32 : snr >= 31 ? 31 : snr));
+            LMIC.devAnsMargin = (u1_t)(0b00111111 & (snr <= -32 ? -32 : snr >= 31 ? 31 : snr));
             oidx += 1;
             continue;
         }

--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -4,7 +4,7 @@
  *
  * Copyright (c) 2016-2018 MCCI Corporation.
  * All rights reserved.
- * 
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
  *  * Redistributions of source code must retain the above copyright
@@ -840,7 +840,7 @@ static bit_t decodeFrame (void) {
 
     // Process OPTS
     int m = LMIC.rssi - RSSI_OFF - getSensitivity(LMIC.rps);
-    LMIC.margin = m < 0 ? 0 : m > 254 ? 254 : m;
+    LMIC.margin = m < 0 ? 0 : m > 31 ? 31 : m;
 
 #if LMIC_DEBUG_LEVEL > 0
     LMIC_DEBUG_PRINTF("%lu: process options (olen=%#x)\n", os_getTime(), olen);

--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -609,6 +609,10 @@ scan_mac_cmds(
         }
         case MCMD_DEVS_REQ: {
             LMIC.devsAns = 1;
+            // LMIC.snr is SNR time 4, convert to real SNR; rounding towards zero.
+            const int snr = (LMIC.snr + 2) / 4;
+            // per [1.02] 5.5. the margin is the SNR.
+            LMIC.devsAnsMargin = (u1_t)(0b00111111 & (snr <= -32 ? -32 : snr >= 31 ? 31 : snr));
             oidx += 1;
             continue;
         }

--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -1263,7 +1263,7 @@ static void buildDataFrame (void) {
     if( LMIC.devsAns ) {  // answer to device status
         LMIC.frame[end+0] = MCMD_DEVS_ANS;
         LMIC.frame[end+1] = os_getBattLevel();
-        LMIC.frame[end+2] = LMIC.margin;
+        LMIC.frame[end+2] = LMIC.devAnsMargin;
         end += 3;
         LMIC.devsAns = 0;
     }

--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -843,6 +843,8 @@ static bit_t decodeFrame (void) {
         LMIC.adrAckReq = LINK_CHECK_INIT;
 
     int m = LMIC.rssi - RSSI_OFF - getSensitivity(LMIC.rps);
+    // for legacy reasons, LMIC.margin is set to the unsigned sensitivity. It can never be negative.
+    // it's only computed for legacy clients
     LMIC.margin = m < 0 ? 0 : m > 254 ? 254 : m;
 
 #if LMIC_DEBUG_LEVEL > 0

--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -4,7 +4,7 @@
  *
  * Copyright (c) 2016-2018 MCCI Corporation.
  * All rights reserved.
- * 
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
  *  * Redistributions of source code must retain the above copyright
@@ -838,11 +838,11 @@ static bit_t decodeFrame (void) {
     if( LMIC.adrAckReq != LINK_CHECK_OFF )
         LMIC.adrAckReq = LINK_CHECK_INIT;
 
-    // Process OPTS
     int m = LMIC.rssi - RSSI_OFF - getSensitivity(LMIC.rps);
     LMIC.margin = m < 0 ? 0 : m > 254 ? 254 : m;
 
 #if LMIC_DEBUG_LEVEL > 0
+    // Process OPTS
     LMIC_DEBUG_PRINTF("%lu: process options (olen=%#x)\n", os_getTime(), olen);
 #endif
 

--- a/src/lmic/lmic.h
+++ b/src/lmic/lmic.h
@@ -253,7 +253,7 @@ struct lmic_t {
 
     u4_t        freq;
     s1_t        rssi;
-    s1_t        snr;            // LMIC.snr is SNR time 4
+    s1_t        snr;            // LMIC.snr is SNR times 4
     rps_t       rps;
     u1_t        rxsyms;
     u1_t        dndr;

--- a/src/lmic/lmic.h
+++ b/src/lmic/lmic.h
@@ -315,6 +315,7 @@ struct lmic_t {
     u1_t        margin;
     bit_t       ladrAns;      // link adr adapt answer pending
     bit_t       devsAns;      // device status answer pending
+    s1_t        devAnsMargin; // SNR value between -32 and 31 (inclusive) for the last successfully received DevStatusReq command
     u1_t        adrEnabled;
     u1_t        moreData;     // NWK has more data pending
 #if !defined(DISABLE_MCMD_DCAP_REQ)

--- a/src/lmic/lmic.h
+++ b/src/lmic/lmic.h
@@ -253,7 +253,7 @@ struct lmic_t {
 
     u4_t        freq;
     s1_t        rssi;
-    s1_t        snr;
+    s1_t        snr;            // LMIC.snr is SNR time 4
     rps_t       rps;
     u1_t        rxsyms;
     u1_t        dndr;


### PR DESCRIPTION
The value of 31 is taken from this [line](https://github.com/brocaar/lorawan/blob/f8d816eb916de4ef3253cc6f1f1036d25a1e324b/mac_commands.go#L563) of the lorawan software.

Fixes #130 