### PR TITLE
Update Arduino IDE version to 1.8.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ before_install:
   - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_1.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :1 -ac -screen 0 1280x1024x16"
   - sleep 3
   - export DISPLAY=:1.0
-  - wget http://downloads.arduino.cc/arduino-1.8.5-linux64.tar.xz
-  - tar xf arduino-1.8.5-linux64.tar.xz
-  - mv arduino-1.8.5 $HOME/arduino_ide
+  - wget http://downloads.arduino.cc/arduino-1.8.7-linux64.tar.xz
+  - tar xf arduino-1.8.7-linux64.tar.xz
+  - mv arduino-1.8.7 $HOME/arduino_ide
   - ln -s $PWD $HOME/arduino_ide/libraries/Test_Library
   - export PATH="$HOME/arduino_ide:$PATH"
   #


### PR DESCRIPTION
This kind of changes could be performed automatically by setting the CI script to always use the latest version of the Arduino.