### PR TITLE
Make SPI pins (MOSI, MISO, SS, SCK) configurable in struct lmic_pinmap

### DIFF
--- a/src/hal/hal.cpp
+++ b/src/hal/hal.cpp
@@ -138,7 +138,7 @@ static void hal_io_check() {
 // SPI
 
 static void hal_spi_init () {
-    SPI.begin();
+    SPI.begin(plmic_pins->sck, plmic_pins->miso, plmic_pins->mosi, plmic_pins->nss);
 }
 
 void hal_pin_nss (u1_t val) {

--- a/src/hal/hal.h
+++ b/src/hal/hal.h
@@ -20,6 +20,9 @@ struct lmic_pinmap {
     u1_t rxtx;                  // byte 1: pin for rx/tx control
     u1_t rst;                   // byte 2: pin for reset
     u1_t dio[NUM_DIO];          // bytes 3..5: pins for DIO0, DOI1, DIO2
+    u1_t mosi;                  // byte 9: pin for master out / slave in (write to LORA chip)
+    u1_t miso;                  // byte 10: pin for master in / slave out (read from LORA chip)
+    u1_t sck;                   // byte 11: pin for serial clock by master
     // true if we must set rxtx for rx_active, false for tx_active
     u1_t rxtx_rx_active;        // byte 6: polarity of rxtx active
     s1_t rssi_cal;              // byte 7: cal in dB -- added to RSSI


### PR DESCRIPTION
using format compatible to [pins_arduino.h](https://github.com/espressif/arduino-esp32/blob/master/variants/t-beam/pins_arduino.h), like

```
// SPI LoRa Radio
#define LORA_SCK 5      // GPIO5  - SX1276 SCK
#define LORA_MISO 19    // GPIO19 - SX1276 MISO
#define LORA_MOSI 27    // GPIO27 - SX1276 MOSI
#define LORA_CS 18      // GPIO18 - SX1276 CS

```