### PR TITLE
Higher level spi

### DIFF
--- a/src/hal/hal.cpp
+++ b/src/hal/hal.cpp
@@ -155,10 +155,11 @@ static void hal_spi_trx(u1_t cmd, u1_t* buf, int len, u1_t is_read) {
     SPI.transfer(cmd);
 
     for (u1_t i = 0; i < len; i++) {
-        u1_t data = is_read ? 0x00 : buf[i];
+        u1_t* p = buf + i;
+        u1_t data = is_read ? 0x00 : *p;
         data = SPI.transfer(data);
         if (is_read)
-            buf[i] = data;
+            *p = data;
     }
 
     digitalWrite(nss, 1);

--- a/src/lmic/hal.h
+++ b/src/lmic/hal.h
@@ -44,11 +44,6 @@ void hal_init (void);
 void hal_init_ex (const void *pContext);
 
 /*
- * drive radio NSS pin (0=low, 1=high).
- */
-void hal_pin_nss (u1_t val);
-
-/*
  * drive radio RX/TX pins (0=rx, 1=tx).
  */
 void hal_pin_rxtx (u1_t val);
@@ -59,11 +54,18 @@ void hal_pin_rxtx (u1_t val);
 void hal_pin_rst (u1_t val);
 
 /*
- * perform 8-bit SPI transaction with radio.
- *   - write given byte 'outval'
- *   - read byte and return value
+ * Perform SPI write transaction with radio chip
+ *   - write the command byte 'cmd'
+ *   - write 'len' bytes out of 'buf'
  */
-u1_t hal_spi (u1_t outval);
+void hal_spi_write(u1_t cmd, const u1_t* buf, int len);
+
+/*
+ * Perform SPI read transaction with radio chip
+ *   - write the command byte 'cmd'
+ *   - read 'len' bytes into 'buf'
+ */
+void hal_spi_read(u1_t cmd, u1_t* buf, int len);
 
 /*
  * disable all CPU interrupts.

--- a/src/lmic/radio.c
+++ b/src/lmic/radio.c
@@ -290,36 +290,21 @@ static u1_t randbuf[16];
 
 
 static void writeReg (u1_t addr, u1_t data ) {
-    hal_pin_nss(0);
-    hal_spi(addr | 0x80);
-    hal_spi(data);
-    hal_pin_nss(1);
+    hal_spi_write(addr | 0x80, &data, 1);
 }
 
 static u1_t readReg (u1_t addr) {
-    hal_pin_nss(0);
-    hal_spi(addr & 0x7F);
-    u1_t val = hal_spi(0x00);
-    hal_pin_nss(1);
-    return val;
+    u1_t buf[1];
+    hal_spi_read(addr & 0x7f, buf, 1);
+    return buf[0];
 }
 
 static void writeBuf (u1_t addr, xref2u1_t buf, u1_t len) {
-    hal_pin_nss(0);
-    hal_spi(addr | 0x80);
-    for (u1_t i=0; i<len; i++) {
-        hal_spi(buf[i]);
-    }
-    hal_pin_nss(1);
+    hal_spi_write(addr | 0x80, buf, len);
 }
 
 static void readBuf (u1_t addr, xref2u1_t buf, u1_t len) {
-    hal_pin_nss(0);
-    hal_spi(addr & 0x7F);
-    for (u1_t i=0; i<len; i++) {
-        buf[i] = hal_spi(0x00);
-    }
-    hal_pin_nss(1);
+    hal_spi_read(addr & 0x7f, buf, len);
 }
 
 static void opmode (u1_t mode) {


### PR DESCRIPTION
As I've seen the pull request related to SPI initialization, I'd like to propose another change to the SPI hardware abstraction layer. Instead of the low-level API:

```C
void hal_pin_nss (u1_t val);
u1_t hal_spi (u1_t outval);
```

introduce a higher-level API:

```C
void hal_spi_write(u1_t cmd, const u1_t* buf, int len);
void hal_spi_read(u1_t cmd, u1_t* buf, int len);
```

The new API simplifies the code as the start and end of the SPI transactions are obvious and don't need to be indirectly derived from the NSS level. My [TTN library for ESP-IDF](https://github.com/manuelbl/ttn-esp32) would also profit as the ESP-IDF API for SPI is designed around entire SPI transactions.

Another benefit is that the code size of the new implementation decreases on all processors that I have tested (slightly at the expense of code readability). The RAM size stays exactly the same.

I cannot judge if there are many alternative HALs that this change will certainly break. If that's the case, feel free to reject the pull request.
