### PR TITLE
Fix #38: Properly initialize NSS, RXTX, RST pins

### DIFF
--- a/src/hal/hal.cpp
+++ b/src/hal/hal.cpp
@@ -33,11 +33,19 @@ static void hal_io_init () {
 //    Serial.print("dio[1]: "); Serial.println(plmic_pins->dio[1]);
 //    Serial.print("dio[2]: "); Serial.println(plmic_pins->dio[2]);
 
+    // initialize SPI chip select to high (it's active low)
+    digitalWrite(plmic_pins->nss, HIGH);
     pinMode(plmic_pins->nss, OUTPUT);
-    if (plmic_pins->rxtx != LMIC_UNUSED_PIN)
+
+    if (plmic_pins->rxtx != LMIC_UNUSED_PIN) {
+        // initialize to RX
+        digitalWrite(plmic_pins->rxtx, LOW != plmic_pins->rxtx_rx_active);
         pinMode(plmic_pins->rxtx, OUTPUT);
-    if (plmic_pins->rst != LMIC_UNUSED_PIN)
-        pinMode(plmic_pins->rst, OUTPUT);
+    }
+    if (plmic_pins->rst != LMIC_UNUSED_PIN) {
+        // initialize RST to floating
+        pinMode(plmic_pins->rst, INPUT);
+    }
 
     hal_interrupt_init();
 }
@@ -54,8 +62,8 @@ void hal_pin_rst (u1_t val) {
         return;
 
     if(val == 0 || val == 1) { // drive pin
-        pinMode(plmic_pins->rst, OUTPUT);
         digitalWrite(plmic_pins->rst, val);
+        pinMode(plmic_pins->rst, OUTPUT);
     } else { // keep pin floating
         pinMode(plmic_pins->rst, INPUT);
     }


### PR DESCRIPTION
Here's a fix for issue #38 (Need to initialize nss pin to HIGH). 

- `writeDigital` is deliberately called before `pinMode(..., OUTPUT)` to avoid spikes on the output pin. This pattern should work on all Arduino implementations.
- *RXTX* is initialized to RX mode.
- *RST* is set to floating. That's the same state the pin is in after the reset has been executed. Before it was implicit set to LOW.