### PR TITLE
Correct ADR ACK request limit.

### DIFF
--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -1837,10 +1837,8 @@ static void engineUpdate (void) {
                     // in AS923 v1.1 or older, no need to change the datarate.
                     txdr = lowerDR(txdr, LMIC.rejoinCnt);
 #endif
-                    ftype = HDR_FTYPE_REJOIN;
-                } else {
-                    ftype = HDR_FTYPE_JREQ;
                 }
+                ftype = HDR_FTYPE_JREQ;
                 buildJoinRequest(ftype);
                 LMIC.osjob.func = FUNC_ADDR(jreqDone);
             } else

--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -1872,6 +1872,8 @@ static void engineUpdate (void) {
             LMIC.dndr   = txdr;  // carry TX datarate (can be != LMIC.datarate) over to txDone/setupRx1
             LMIC.opmode = (LMIC.opmode & ~(OP_POLL|OP_RNDTX)) | OP_TXRXPEND | OP_NEXTCHNL;
             LMICbandplan_updateTx(txbeg);
+            // limit power to value ask in adr
+            LMIC.txpow = LMIC.txpow > LMIC.adrTxPow ? LMIC.adrTxPow : LMIC.txpow;
             reportEvent(EV_TXSTART);
             os_radio(RADIO_TX);
             return;

--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -1658,9 +1658,16 @@ static bit_t processDnData (void) {
             EV(devCond, ERR, (e_.reason = EV::devCond_t::LINK_DEAD,
                               e_.eui    = MAIN::CDEV->getEui(),
                               e_.info   = LMIC.adrAckReq));
-            setDrTxpow(DRCHG_NOADRACK, decDR((dr_t)LMIC.datarate), KEEP_TXPOW);
+            dr_t newDr = decDR((dr_t)LMIC.datarate);
+            if( newDr == (dr_t)LMIC.datarate) {
+                // We are already at the minimum datarate
+                // try to REJOIN
+                LMIC.opmode |= OP_REJOIN;
+            }
+            // Decrease DataRate and restore fullpower.
+            setDrTxpow(DRCHG_NOADRACK, newDr, pow2dBm(0));
             LMIC.adrAckReq = LINK_CHECK_CONT;
-            LMIC.opmode |= OP_REJOIN|OP_LINKDEAD;
+            LMIC.opmode |= OP_LINKDEAD;
             reportEvent(EV_LINK_DEAD);
         }
 #if !defined(DISABLE_BEACONS)

--- a/src/lmic/lmic.h
+++ b/src/lmic/lmic.h
@@ -127,9 +127,9 @@ enum { TXCONF_ATTEMPTS    =   8 };   //!< Transmit attempts for confirmed frames
 enum { MAX_MISSED_BCNS    =  20 };   // threshold for triggering rejoin requests
 enum { MAX_RXSYMS         = 100 };   // stop tracking beacon beyond this
 
-enum { LINK_CHECK_CONT    =  12 ,    // continue with this after reported dead link
-       LINK_CHECK_DEAD    =  24 ,    // after this UP frames and no response from NWK assume link is dead
-       LINK_CHECK_INIT    = -12 ,    // UP frame count until we inc datarate
+enum { LINK_CHECK_CONT    =  0  ,    // continue with this after reported dead link
+       LINK_CHECK_DEAD    =  32 ,    // after this UP frames and no response to ack from NWK assume link is dead (ADR_ACK_DELAY)
+       LINK_CHECK_INIT    = -64 ,    // UP frame count until we ark for ack (ADR_ACK_LIMIT)
        LINK_CHECK_OFF     =-128 };   // link check disabled
 
 enum { TIME_RESYNC        = 6*128 }; // secs

--- a/src/lmic/lmic_as923.c
+++ b/src/lmic/lmic_as923.c
@@ -138,7 +138,7 @@ int8_t LMICas923_pow2dBm(uint8_t mcmd_ladr_p1) {
 			(mcmd_ladr_p1&MCMD_LADR_POW_MASK)>>MCMD_LADR_POW_SHIFT
 			);
 			
-	return adj;
+	return LMICas923_getMaxEIRP(LMIC.txParam) + adj;
 }
 
 // only used in this module, but used by variant macro dr2hsym().

--- a/src/lmic/lmic_eu868.c
+++ b/src/lmic/lmic_eu868.c
@@ -59,7 +59,7 @@ uint8_t LMICeu868_maxFrameLen(uint8_t dr) {
 }
 
 static CONST_TABLE(s1_t, TXPOWLEVELS)[] = {
-        20, 14, 11, 8, 5, 2, 0,0, 0,0,0,0, 0,0,0,0
+        16, 14, 12, 10, 8, 6, 4, 2, 0,0,0,0, 0,0,0,0
 };
 
 int8_t LMICeu868_pow2dBm(uint8_t mcmd_ladr_p1) {

--- a/src/lmic/lmic_in866.c
+++ b/src/lmic/lmic_in866.c
@@ -59,7 +59,7 @@ uint8_t LMICin866_maxFrameLen(uint8_t dr) {
 }
 
 static CONST_TABLE(s1_t, TXPOWLEVELS)[] = {
-        20, 14, 11, 8, 5, 2, 0,0, 0,0,0,0, 0,0,0,0
+        30, 28, 26, 24, 22, 20, 18, 16, 14, 12, 10, 0, 0,0,0,0
 };
 
 int8_t LMICin866_pow2dBm(uint8_t mcmd_ladr_p1) {

--- a/src/lmic/lorabase.h
+++ b/src/lmic/lorabase.h
@@ -414,7 +414,6 @@ enum {
     HDR_FTYPE_DADN   = 0x60,  // data (unconfirmed) dn
     HDR_FTYPE_DCUP   = 0x80,  // data confirmed up
     HDR_FTYPE_DCDN   = 0xA0,  // data confirmed dn
-    HDR_FTYPE_REJOIN = 0xC0,  // rejoin for roaming
     HDR_FTYPE_PROP   = 0xE0
 };
 enum {


### PR DESCRIPTION
"After ADR_ACK_LIMIT uplinks (ADR_ACK_CNT >=ADR_ACK_LIMIT) without any downlink response, it sets the ADR acknowledgment request bit (ADRACKReq)"
"The network is required to respond with a downlink frame within the next ADR_ACK_DELAY frames, any received downlink frame following an uplink frame resets the ADR_ACK_CNT counter".

LMIC set ADRACKReq if LMIC.adrAckReq (ie. ADR_ACK_CNT) is > 0 and set link down if > LINK_CHECK_INIT.

So set LINK_CHECK_INIT to -ADR_ACK_LIMIT and LINK_CHECK_DEAD to ADR_ACK_DELAY.

Should close #53 