### PR TITLE
Remove some old comment in sample about txpow.

### DIFF
--- a/examples/ttn-abp-feather-us915-dht22/ttn-abp-feather-us915-dht22.ino
+++ b/examples/ttn-abp-feather-us915-dht22/ttn-abp-feather-us915-dht22.ino
@@ -254,7 +254,7 @@ void setup() {
     // TTN uses SF9 for its RX2 window.
     LMIC.dn2Dr = DR_SF9;
 
-    // Set data rate and transmit power for uplink (note: txpow seems to be ignored by the library)
+    // Set data rate and transmit power for uplink
     LMIC_setDrTxpow(DR_SF7,14);
 
     // Start job

--- a/examples/ttn-abp/ttn-abp.ino
+++ b/examples/ttn-abp/ttn-abp.ino
@@ -254,7 +254,7 @@ void setup() {
     // TTN uses SF9 for its RX2 window.
     LMIC.dn2Dr = DR_SF9;
 
-    // Set data rate and transmit power for uplink (note: txpow seems to be ignored by the library)
+    // Set data rate and transmit power for uplink
     LMIC_setDrTxpow(DR_SF7,14);
 
     // Start job


### PR DESCRIPTION
With the change in PR #196, comments "txpow seems to be ignored by the library" can be remove.