### PR TITLE
Further ADR cleanups

### DIFF
--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -712,7 +712,7 @@ scan_mac_cmds(
                     changes = 1;
                 }
                 changes |= setDrTxpow(DRCHG_NWKCMD, dr, pow2dBm(p1));
-                LMIC.adrChanged = 1;  // move the ADR FSM up to "time to request"
+                LMIC.adrChanged = changes;  // move the ADR FSM up to "time to request"
             }
             continue;
         }

--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -653,6 +653,86 @@ static int decodeBeacon (void) {
 }
 #endif // !DISABLE_BEACONS
 
+static CONST_TABLE(u1_t, macCmdSize)[] = {
+    /* 2: LinkCheckAns */ 3,
+    /* 3: LinkADRReq */ 5,
+    /* 4: DutyCycleReq */ 2,
+    /* 5: RXParamSetupReq */ 5,
+    /* 6: DevStatusReq */ 1,
+    /* 7: NewChannel Req */ 6,
+    /* 8: RXTiminSetupReq */ 2,
+    /* 9: TxParamSetupReq */ 2,
+    /* 0x0A: DlChannelReq */ 5,
+    /* B, C: RFU */ 0, 0,
+    /* 0x0D: DeviceTimeAns */ 6,
+    /* 0x0E, 0x0F */ 0, 0,
+    /* 0x10: PingSlotInfoAns */ 1,
+    /* 0x11: PingSlotChannelReq */ 4,
+    /* 0x12: BeaconTimingAns */ 4,
+    /* 0x13: BeaconFreqReq */ 4
+};
+
+static u1_t getMacCmdSize(u1_t macCmd) {
+    if (macCmd < 2)
+        return 0;
+    if (macCmd >= LENOF_TABLE(macCmdSize) - 2)
+        return 0;
+    return TABLE_GET_U1(macCmdSize, macCmd - 2);
+}
+
+static void
+applyAdrRequests(
+    const uint8_t *opts,
+    int olen
+) {
+    if( (LMIC.ladrAns & 0x7F) == (MCMD_LADR_ANS_POWACK | MCMD_LADR_ANS_CHACK | MCMD_LADR_ANS_DRACK) ) {
+        lmic_saved_adr_state_t initialState;
+        int oidx;
+        u1_t p1 = 0;
+        u1_t p4 = 0;
+
+        LMICbandplan_saveAdrState(&initialState);
+
+        for (oidx = 0; oidx < olen; ) {
+            u1_t const cmd = opts[oidx];
+
+            if (cmd == MCMD_LADR_REQ) {
+                u2_t chmap  = os_rlsbf2(&opts[oidx+2]);// list of enabled channels
+
+                p1     = opts[oidx+1];            // txpow + DR, in case last
+                p4     = opts[oidx+4];
+                u1_t chpage = p4 & MCMD_LADR_CHPAGE_MASK;     // channel page
+
+                LMICbandplan_mapChannels(chpage, chmap);
+            }
+
+            int cmdlen = getMacCmdSize(cmd);
+
+            // this really is an assert, we should never here
+            // unless all the commands are valid.
+            ASSERT(cmdlen != 0);
+
+            oidx += cmdlen;
+        }
+
+        // all done scanning options
+        bit_t changes = LMICbandplan_compareAdrState(&initialState);
+
+        // handle uplink repeat count
+        u1_t uprpt  = p4 & MCMD_LADR_REPEAT_MASK;     // up repeat count
+        if (LMIC.upRepeat != uprpt) {
+            LMIC.upRepeat = uprpt;
+            changes = 1;
+        }
+
+        // handle power changes
+        dr_t dr = (dr_t)(p1>>MCMD_LADR_DR_SHIFT);
+        changes |= setDrTxpow(DRCHG_NWKCMD, dr, pow2dBm(p1));
+
+        LMIC.adrChanged = changes;  // move the ADR FSM up to "time to request"
+    }
+}
+
 // scan mac commands starting at opts[] for olen, return count of bytes consumed.
 static int
 scan_mac_cmds(
@@ -660,27 +740,35 @@ scan_mac_cmds(
     int olen
     ) {
     int oidx = 0;
+    // this parser is *really* fragile, especially for LinkADR requests.
+    // it won't crash, but acks will be wrong if all ADR requests are
+    // not contiguous.
+    bit_t fSawAdrReq;
+    uint8_t cmd;
+
     while( oidx < olen ) {
-        switch( opts[oidx] ) {
+        cmd = opts[oidx];
+        switch( cmd ) {
         case MCMD_LCHK_ANS: {
             //int gwmargin = opts[oidx+1];
             //int ngws = opts[oidx+2];
-            oidx += 3;
-            continue;
+            break;
         }
         case MCMD_LADR_REQ: {
             u1_t p1     = opts[oidx+1];            // txpow + DR
             u2_t chmap  = os_rlsbf2(&opts[oidx+2]);// list of enabled channels
             u1_t chpage = opts[oidx+4] & MCMD_LADR_CHPAGE_MASK;     // channel page
             u1_t uprpt  = opts[oidx+4] & MCMD_LADR_REPEAT_MASK;     // up repeat count
-            oidx += 5;
 
             // TODO(tmm@mcci.com): LoRaWAN 1.1 requires us to process multiple
             // LADR requests, and only update if all pass. So this should check
             // ladrAns == 0, and only initialize if so. Need to repeat ACKs, so
             // we need to count the number we see.
-            LMIC.ladrAns = 0x80 |     // Include an answer into next frame up
-                MCMD_LADR_ANS_POWACK | MCMD_LADR_ANS_CHACK | MCMD_LADR_ANS_DRACK;
+            if (! fSawAdrReq) {
+                fSawAdrReq = 1;
+                LMIC.ladrAns = 0x80 |     // Include an answer into next frame up
+                    MCMD_LADR_ANS_POWACK | MCMD_LADR_ANS_CHACK | MCMD_LADR_ANS_DRACK;
+            }
             if( !LMICbandplan_canMapChannels(chpage, chmap) )
                 LMIC.ladrAns &= ~MCMD_LADR_ANS_CHACK;
             dr_t dr = (dr_t)(p1>>MCMD_LADR_DR_SHIFT);
@@ -691,29 +779,7 @@ scan_mac_cmds(
                                    e_.info   = Base::lsbf4(&d[pend]),
                                    e_.info2  = Base::msbf4(&opts[oidx-4])));
             }
-            // TODO(tmm@mcci.com): see above; this needs to move outside the
-            // txloop. And we need to have "consistent" answers for the block
-            // of contiguous commands (whatever that means), and ignore the
-            // data rate, NbTrans (uprpt) and txPow until the last one.
-#if LMIC_DEBUG_LEVEL > 0
-            LMIC_DEBUG_PRINTF("%"LMIC_PRId_ostime_t": LinkAdrReq: p1:%02x chmap:%04x chpage:%02x uprt:%02x ans:%02x\n",
-		os_getTime(), p1, chmap, chpage, uprpt, LMIC.ladrAns
-		);
-#endif /* LMIC_DEBUG_LEVEL */
-
-            if( (LMIC.ladrAns & 0x7F) == (MCMD_LADR_ANS_POWACK | MCMD_LADR_ANS_CHACK | MCMD_LADR_ANS_DRACK) ) {
-                bit_t changes = 0;
-
-                // Nothing went wrong - use settings
-                changes |= LMICbandplan_mapChannels(chpage, chmap);
-                if (LMIC.upRepeat != uprpt) {
-                    LMIC.upRepeat = uprpt;
-                    changes = 1;
-                }
-                changes |= setDrTxpow(DRCHG_NWKCMD, dr, pow2dBm(p1));
-                LMIC.adrChanged = changes;  // move the ADR FSM up to "time to request"
-            }
-            continue;
+            break;
         }
         case MCMD_DEVS_REQ: {
             LMIC.devsAns = 1;
@@ -721,8 +787,7 @@ scan_mac_cmds(
             const int snr = (LMIC.snr + 2) / 4;
             // per [1.02] 5.5. the margin is the SNR.
             LMIC.devAnsMargin = (u1_t)(0b00111111 & (snr <= -32 ? -32 : snr >= 31 ? 31 : snr));
-            oidx += 1;
-            continue;
+            break;
         }
         case MCMD_DN2P_SET: {
 #if !defined(DISABLE_MCMD_DN2P_SET)
@@ -745,8 +810,7 @@ scan_mac_cmds(
                 DO_DEVDB(LMIC.dn2Freq,dn2Freq);
             }
 #endif // !DISABLE_MCMD_DN2P_SET
-            oidx += 5;
-            continue;
+            break;
         }
         case MCMD_DCAP_REQ: {
 #if !defined(DISABLE_MCMD_DCAP_REQ)
@@ -758,9 +822,8 @@ scan_mac_cmds(
             LMIC.globalDutyAvail = os_getTime();
             DO_DEVDB(cap,dutyCap);
             LMIC.dutyCapAns = 1;
-            oidx += 2;
 #endif // !DISABLE_MCMD_DCAP_REQ
-            continue;
+            break;
         }
         case MCMD_SNCH_REQ: {
 #if !defined(DISABLE_MCMD_SNCH_REQ)
@@ -771,8 +834,7 @@ scan_mac_cmds(
             if( freq != 0 && LMIC_setupChannel(chidx, freq, DR_RANGE_MAP(drs&0xF,drs>>4), -1) )
                 LMIC.snchAns |= MCMD_SNCH_ANS_DRACK|MCMD_SNCH_ANS_FQACK;
 #endif // !DISABLE_MCMD_SNCH_REQ
-            oidx += 6;
-            continue;
+            break;
         }
         case MCMD_PING_SET: {
 #if !defined(DISABLE_MCMD_PING_SET) && !defined(DISABLE_PING)
@@ -787,8 +849,7 @@ scan_mac_cmds(
             }
             LMIC.pingSetAns = flags;
 #endif // !DISABLE_MCMD_PING_SET && !DISABLE_PING
-            oidx += 4;
-            continue;
+            break;
         }
         case MCMD_BCNI_ANS: {
 #if !defined(DISABLE_MCMD_BCNI_ANS) && !defined(DISABLE_BEACONS)
@@ -816,8 +877,7 @@ scan_mac_cmds(
                                      e_.time    = MAIN::CDEV->ostime2ustime(LMIC.bcninfo.txtime + BCN_INTV_osticks)));
             }
 #endif // !DISABLE_MCMD_BCNI_ANS && !DISABLE_BEACONS
-            oidx += 4;
-            continue;
+            break;
         } /* end case */
         case MCMD_TxParamSetupReq: {
 #if LMIC_ENABLE_TxParamSetupReq
@@ -831,8 +891,7 @@ scan_mac_cmds(
             LMIC.txParam = txParam;
             LMIC.txParamSetupAns = 1;
 #endif // LMIC_ENABLE_TxParamSetupReq
-            oidx += 2;
-            continue;
+            break;
         } /* end case */
         case MCMD_DeviceTimeAns: {
 #if LMIC_ENABLE_DeviceTimeReq
@@ -863,18 +922,31 @@ scan_mac_cmds(
 #endif
             }
 #endif // LMIC_ENABLE_DeviceTimeReq
-            oidx += 6;
-            continue;
+            break;
+        } /* end case */
+
+        default: {
+            // force olen to current oidx so we'll exit the while()
+            olen = oidx;
+            break;
         } /* end case */
         } /* end switch */
-        /* unrecognized mac commands fall out of switch to here */
-        EV(specCond, ERR, (e_.reason = EV::specCond_t::BAD_MAC_CMD,
-                           e_.eui    = MAIN::CDEV->getEui(),
-                           e_.info   = Base::lsbf4(&d[pend]),
-                           e_.info2  = Base::msbf4(&opts[oidx])));
-        /* stop processing options */
-        break;
+
+    /* compute length, and exit for illegal commands */
+    int const cmdlen = getMacCmdSize(cmd);
+    if (cmdlen == 0) {
+        // "the first unknown command terminates processing"
+        // force olen to current oidx so we'll exit the while().
+        olen = oidx;
+    }
+
+    oidx += cmdlen;
     } /* end while */
+
+    // go back and apply the ADR changes, if any -- use the effective length
+    if (fSawAdrReq)
+        applyAdrRequests(opts, olen);
+
     return oidx;
 }
 
@@ -1004,6 +1076,7 @@ static bit_t decodeFrame (void) {
         EV(specCond, ERR, (e_.reason = EV::specCond_t::CORRUPTED_FRAME,
                            e_.eui    = MAIN::CDEV->getEui(),
                            e_.info   = 0x1000000 + (oidx) + (olen<<8)));
+        oidx = olen;
     }
 
     if( !replayConf ) {

--- a/src/lmic/lmic.h
+++ b/src/lmic/lmic.h
@@ -156,11 +156,22 @@ struct band_t {
 };
 TYPEDEF_xref2band_t; //!< \internal
 
+struct lmic_saved_adr_state_s {
+    u4_t        channelFreq[MAX_CHANNELS];
+    u2_t        channelMap;
+};
+
 #elif CFG_LMIC_US_like  // US915 spectrum =================================================
 
 enum { MAX_XCHANNELS = 2 };      // extra channels in RAM, channels 0-71 are immutable
 
+struct lmic_saved_adr_state_s {
+    u2_t        channelMap[(72+MAX_XCHANNELS+15)/16];  // enabled bits
+};
+
 #endif // ==========================================================================
+
+typedef struct lmic_saved_adr_state_s   lmic_saved_adr_state_t;
 
 // Keep in sync with evdefs.hpp::drChange
 enum { DRCHG_SET, DRCHG_NOJACC, DRCHG_NOACK, DRCHG_NOADRACK, DRCHG_NWKCMD };

--- a/src/lmic/lmic_bandplan.h
+++ b/src/lmic/lmic_bandplan.h
@@ -1,6 +1,6 @@
 /*
 * Copyright (c) 2014-2016 IBM Corporation.
-* Copyright (c) 2017 MCCI Corporation.
+* Copyright (c) 2017, 2019 MCCI Corporation.
 * All rights reserved.
 *
 *  Redistribution and use in source and binary forms, with or without
@@ -147,6 +147,15 @@
 #if !defined(LMICbandplan_init)
 # error "LMICbandplan_init() not defined by bandplan"
 #endif
+
+#if !defined(LMICbandplan_saveAdrState)
+# error "LMICbandplan_saveAdrState() not defined by bandplan"
+#endif
+
+#if !defined(LMICbandplan_compareAdrState)
+# error "LMICbandplan_compareAdrState() not defined by bandplan"
+#endif
+
 //
 // Things common to lmic.c code
 //

--- a/src/lmic/lmic_eu_like.c
+++ b/src/lmic/lmic_eu_like.c
@@ -169,4 +169,19 @@ ostime_t LMICeulike_nextJoinState(uint8_t nDefaultChannels) {
 }
 #endif // !DISABLE_JOIN
 
+void LMICeulike_saveAdrState(lmic_saved_adr_state_t *pStateBuffer) {
+        memcpy(
+                pStateBuffer->channelFreq,
+                LMIC.channelFreq,
+                sizeof(LMIC.channelFreq)
+        );
+        pStateBuffer->channelMap = LMIC.channelMap;
+}
+
+bit_t LMICeulike_compareAdrState(const lmic_saved_adr_state_t *pStateBuffer) {
+        if (memcmp(pStateBuffer->channelFreq, LMIC.channelFreq, sizeof(LMIC.channelFreq)) != 0)
+                return 0;
+        return pStateBuffer->channelMap == LMIC.channelMap;
+}
+
 #endif // CFG_LMIC_EU_like

--- a/src/lmic/lmic_eu_like.h
+++ b/src/lmic/lmic_eu_like.h
@@ -95,4 +95,10 @@ static inline ostime_t LMICeulike_nextJoinTime(ostime_t now) {
 #define LMICbandplan_init()     \
         do { /* nothing */ } while (0)
 
+void LMICeulike_saveAdrState(lmic_saved_adr_state_t *pStateBuffer);
+#define LMICbandplan_saveAdrState(pState) LMICeulike_saveAdrState(pState)
+
+bit_t LMICeulike_compareAdrState(const lmic_saved_adr_state_t *pStateBuffer);
+#define LMICbandplan_compareAdrState(pState) LMICeulike_compareAdrState(pState)
+
 #endif // _lmic_eu_like_h_

--- a/src/lmic/lmic_us_like.c
+++ b/src/lmic/lmic_us_like.c
@@ -286,4 +286,16 @@ ostime_t LMICuslike_nextJoinState(void) {
 }
 #endif
 
+void LMICuslike_saveAdrState(lmic_saved_adr_state_t *pStateBuffer) {
+        memcpy(
+                pStateBuffer->channelMap,
+                LMIC.channelMap,
+                sizeof(LMIC.channelMap)
+        );
+}
+
+bit_t LMICuslike_compareAdrState(const lmic_saved_adr_state_t *pStateBuffer) {
+        return memcmp(pStateBuffer->channelMap, LMIC.channelMap, sizeof(LMIC.channelMap)) != 0;
+}
+
 #endif // CFG_LMIC_US_like

--- a/src/lmic/lmic_us_like.h
+++ b/src/lmic/lmic_us_like.h
@@ -100,4 +100,10 @@ static inline ostime_t LMICuslike_nextJoinTime(ostime_t now) {
 #define LMICbandplan_init()     \
         do { /* nothing */ } while (0)
 
+void LMICuslike_saveAdrState(lmic_saved_adr_state_t *pStateBuffer);
+#define LMICbandplan_saveAdrState(pState) LMICuslike_saveAdrState(pState)
+
+bit_t LMICuslike_compareAdrState(const lmic_saved_adr_state_t *pStateBuffer);
+#define LMICbandplan_compareAdrState(pState) LMICuslike_compareAdrState(pState)
+
 #endif // _lmic_us_like_h_


### PR DESCRIPTION
ADR for US915 and AU915 was still broken; ADR changes were still not atomic for multiple requests. Send an ADR request when we start a session (without joining).