### PR TITLE
correctly manage transmission power with addition of a MAX_RFO_PWR se…

### DIFF
--- a/project_config/lmic_project_config.h
+++ b/project_config/lmic_project_config.h
@@ -7,3 +7,6 @@
 //#define CFG_in866 1
 #define CFG_sx1276_radio 1
 //#define LMIC_USE_INTERRUPTS
+
+// Max RFO Power 0 when no power amplifier behind RFO
+#define MAX_RFO_PWR 0


### PR DESCRIPTION
…tting
The objective is to correctly manage the TX power setting on sx1276 with an optimal current consumption.
The MAX_RFO_PWR allows to set the limit between use of PA_BOOST vs RFO. When the device does not have RFO connected like for RFM95 this setting must be set to 0.