### PR TITLE
Fix potential index-out-of-bounds issue

### DIFF
--- a/src/lmic/lmic_compliance.c
+++ b/src/lmic/lmic_compliance.c
@@ -417,7 +417,7 @@ Returns:
 static const char * lmic_compliance_fsmstate_Getname(lmic_compliance_fsmstate_t state) {
     const char * const names[] = { LMIC_COMPLIANCE_FSMSTATE__NAMES };
 
-    if ((unsigned) state > sizeof(names)/sizeof(names[0]))
+    if ((unsigned) state >= sizeof(names)/sizeof(names[0]))
         return "<<unknown>>";
     else
         return names[state];


### PR DESCRIPTION
in lmic_compliance_fsmstate_Getname (found by cppcheck --enable=all)

The logic is off-by-one. There are 9 states (0-8). The comparison is wrong, a value of 9 for variable state is also an "unknown state", hence the added equals sign.

This was found by running cppcheck with argument --enable=all on the lmic code. 