### PR TITLE
Optionally disable downlinks to save power

### DIFF
--- a/src/lmic/config.h
+++ b/src/lmic/config.h
@@ -47,7 +47,7 @@
 //#define CFG_sx1272_radio 1
 // This is the SX1276/SX1277/SX1278/SX1279 radio, which is also used on
 // the HopeRF RFM95 boards.
-#define CFG_sx1276_radio 1
+//#define CFG_sx1276_radio 1
 
 // ensure that a radio is defined.
 #if ! (defined(CFG_sx1272_radio) || defined(CFG_sx1276_radio))

--- a/src/lmic/config.h
+++ b/src/lmic/config.h
@@ -47,7 +47,7 @@
 //#define CFG_sx1272_radio 1
 // This is the SX1276/SX1277/SX1278/SX1279 radio, which is also used on
 // the HopeRF RFM95 boards.
-//#define CFG_sx1276_radio 1
+#define CFG_sx1276_radio 1
 
 // ensure that a radio is defined.
 #if ! (defined(CFG_sx1272_radio) || defined(CFG_sx1276_radio))
@@ -189,5 +189,13 @@
 #if !defined(LMIC_ENABLE_long_messages)
 # define LMIC_ENABLE_long_messages 1        /* PARAM */
 #endif
+
+// LMIC_DISABLE_DOWNLINK
+// Disable any downlink action on the node. Trigger EV_TXCOMPLETE just after
+// completing the uplink. This feature is specially useful for low-power devices
+// not in the need to receive downlink packets from server. This flag prevents the
+// node from having wait to around five seconds (DNW2_SAFETY_ZONE + LMICcore_rndDelay(2))
+// before going to sleep
+#define LMIC_DISABLE_DOWNLINK 1
 
 #endif // _lmic_config_h_

--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -1476,11 +1476,16 @@ static void processRx2DnData (xref2osjob_t osjob) {
 
     if( LMIC.dataLen == 0 ) {
         initTxrxFlags(__func__, 0);  // nothing in 1st/2nd DN slot
+
+        #ifdef LMIC_DISABLE_DOWNLINK
+        os_setTimedCallback(&LMIC.osjob, os_getTime(), FUNC_ADDR(processRx2DnDataDelay));
+        #else
         // Delay callback processing to avoid up TX while gateway is txing our missed frame!
         // Since DNW2 uses SF12 by default we wait 3 secs.
         os_setTimedCallback(&LMIC.osjob,
                             (os_getTime() + DNW2_SAFETY_ZONE + LMICcore_rndDelay(2)),
                             FUNC_ADDR(processRx2DnDataDelay));
+        #endif
         return;
     }
     processDnData();


### PR DESCRIPTION
I added a LMIC_DISABLE_DOWNLINK definition in lmic/config.h in order to remove DNW2_SAFETY_ZONE + LMICcore_rndDelay(2) in processRx2DnData and then save around 5 seconds between transmission and reception of EV_TXCOMPLETE.

Low-power nodes which do not need downlinks can take advantage of this feature in order to save a lot of current.

I'm still looking around how to remove the 1.5-2 second delay still happening before EV_TXCOMPLETE