### PR TITLE
Fix #317: adapt better to Adafruit BSPs

### DIFF
--- a/examples/raw-feather/raw-feather.ino
+++ b/examples/raw-feather/raw-feather.ino
@@ -57,7 +57,11 @@ Author:
 #define RX_RSSI_INTERVAL 100    // milliseconds
 
 // Pin mapping for Adafruit Feather M0 LoRa, etc.
-#if defined(ARDUINO_SAMD_FEATHER_M0)
+//
+// Adafruit BSPs are not consistent -- m0 express defs ARDUINO_SAMD_FEATHER_M0, 
+// m0 defs ADAFRUIT_FEATHER_M0
+//
+#if defined(ARDUINO_SAMD_FEATHER_M0) || defined(ADAFRUIT_FEATHER_M0)
 const lmic_pinmap lmic_pins = {
     .nss = 8,
     .rxtx = LMIC_UNUSED_PIN,

--- a/examples/ttn-otaa-feather-us915/ttn-otaa-feather-us915.ino
+++ b/examples/ttn-otaa-feather-us915/ttn-otaa-feather-us915.ino
@@ -75,7 +75,11 @@ static osjob_t sendjob;
 const unsigned TX_INTERVAL = 60;
 
 // Pin mapping
-#if defined(ARDUINO_SAMD_FEATHER_M0)
+//
+// Adafruit BSPs are not consistent -- m0 express defs ARDUINO_SAMD_FEATHER_M0, 
+// m0 defs ADAFRUIT_FEATHER_M0
+//
+#if defined(ARDUINO_SAMD_FEATHER_M0) || defined(ADAFRUIT_FEATHER_M0)
 // Pin mapping for Adafruit Feather M0 LoRa, etc.
 const lmic_pinmap lmic_pins = {
     .nss = 8,

--- a/src/hal/getpinmap_thisboard.cpp
+++ b/src/hal/getpinmap_thisboard.cpp
@@ -19,7 +19,11 @@ namespace Arduino_LMIC {
 
 const HalPinmap_t *GetPinmap_ThisBoard(void)
         {
-#if defined(ARDUINO_SAMD_FEATHER_M0)
+/*
+|| Adafruit BSPs are not consistent -- m0 express defs ARDUINO_SAMD_FEATHER_M0, 
+|| m0 defs ADAFRUIT_FEATHER_M0
+*/
+#if defined(ARDUINO_SAMD_FEATHER_M0) || defined(ADAFRUIT_FEATHER_M0)
 # if defined(ARDUINO_MCCI_CATENA_4420)
         // this uses a radiowing and an odd configuration
         return GetPinmap_Catena4420();

--- a/src/lmic/lmic.h
+++ b/src/lmic/lmic.h
@@ -105,7 +105,7 @@ extern "C"{
 #define ARDUINO_LMIC_VERSION_CALC(major, minor, patch, local)	\
 	(((major) << 24u) | ((minor) << 16u) | ((patch) << 8u) | (local))
 
-#define	ARDUINO_LMIC_VERSION	ARDUINO_LMIC_VERSION_CALC(2, 3, 2, 50)	/* v2.3.2.50 */
+#define	ARDUINO_LMIC_VERSION	ARDUINO_LMIC_VERSION_CALC(2, 3, 2, 51)	/* v2.3.2.51 */
 
 #define	ARDUINO_LMIC_VERSION_GET_MAJOR(v)	\
 	(((v) >> 24u) & 0xFFu)


### PR DESCRIPTION
Adafruit BSPs are not consistent -- Featherr M0 Express defines `ARDUINO_SAMD_FEATHER_M0`,  while Feather M0 defines `ADAFRUIT_FEATHER_M0`. So we need to check for both.

Bump local version to 2.3.2.51.