### PR TITLE
Fix #46: make Tx Pwr policy explicit; see #300 (WIP)

### DIFF
--- a/src/arduino_lmic_hal_configuration.h
+++ b/src/arduino_lmic_hal_configuration.h
@@ -62,7 +62,7 @@ struct HalPinmap_t {
 				//   Must include noise guardband!
 	uint32_t spi_freq;	// bytes 8..11: SPI freq in Hz.
 
-	// optional pointer to configuration object (byest 12..15)
+	// optional pointer to configuration object (bytes 12..15)
 	HalConfiguration_t *pConfig;
 	};
 

--- a/src/arduino_lmic_hal_configuration.h
+++ b/src/arduino_lmic_hal_configuration.h
@@ -71,6 +71,14 @@ class HalConfiguration_t
 public:
 	HalConfiguration_t() {};
 
+	// these must match the constants in radio.c
+	enum class TxPowerPolicy_t : uint8_t
+		{
+		RFO,
+		PA_BOOST,
+		PA_BOOST_20dBm
+		};
+
 	virtual ostime_t setModuleActive(bool state) {
 		LMIC_API_PARAMETER(state);
 
@@ -83,6 +91,20 @@ public:
 	virtual void begin(void) {}
 	virtual void end(void) {}
 	virtual bool queryUsingTcxo(void) { return false; }
+
+	// compute desired transmit power policy.
+	virtual TxPowerPolicy_t getTxPowerPolicy(
+		TxPowerPolicy_t policy,
+		int8_t requestedPower,
+		uint32_t frequency
+		)
+		{
+		// default: do use PA_BOOST, don't use PA_BOOST_20dBm
+		if (policy == TxPowerPolicy_t::PA_BOOST_20dBm)
+			return TxPowerPolicy_t::PA_BOOST;
+		else
+			return policy;
+		}
 	};
 
 bool hal_init_with_pinmap(const HalPinmap_t *pPinmap);

--- a/src/arduino_lmic_hal_configuration.h
+++ b/src/arduino_lmic_hal_configuration.h
@@ -92,18 +92,18 @@ public:
 	virtual void end(void) {}
 	virtual bool queryUsingTcxo(void) { return false; }
 
-	// compute desired transmit power policy.
+	// compute desired transmit power policy.  HopeRF needs
+	// (and previous versions of this library always chose)
+	// PA_BOOST mode. So that's our default. Override this
+	// for the Murata module.
 	virtual TxPowerPolicy_t getTxPowerPolicy(
 		TxPowerPolicy_t policy,
 		int8_t requestedPower,
 		uint32_t frequency
 		)
 		{
-		// default: do use PA_BOOST, don't use PA_BOOST_20dBm
-		if (policy == TxPowerPolicy_t::PA_BOOST_20dBm)
-			return TxPowerPolicy_t::PA_BOOST;
-		else
-			return policy;
+		// default: use PA_BOOST exclusively
+		return TxPowerPolicy_t::PA_BOOST;
 		}
 	};
 

--- a/src/hal/hal.cpp
+++ b/src/hal/hal.cpp
@@ -425,3 +425,15 @@ ostime_t hal_setModuleActive (bit_t val) {
 bit_t hal_queryUsingTcxo(void) {
     return pHalConfig->queryUsingTcxo();
 }
+
+uint8_t hal_getTxPowerPolicy(
+    u1_t inputPolicy,
+    s1_t requestedPower,
+    u4_t frequency
+    ) {
+    return (uint8_t) pHalConfig->getTxPowerPolicy(
+                        Arduino_LMIC::HalConfiguration_t::TxPowerPolicy_t(inputPolicy),
+                        requestedPower,
+                        frequency
+                        );
+}

--- a/src/lmic/hal.h
+++ b/src/lmic/hal.h
@@ -147,7 +147,26 @@ s1_t hal_getRssiCal (void);
  */
 ostime_t hal_setModuleActive (bit_t val);
 
+/* find out if we're using Tcxo */
 bit_t hal_queryUsingTcxo(void);
+
+/* represent the various radio TX power policy */
+enum	{
+	LMICHAL_radio_tx_power_policy_rfo	= 0,
+	LMICHAL_radio_tx_power_policy_paboost	= 1,
+	LMICHAL_radio_tx_power_policy_20dBm	= 2,
+};
+
+/*
+ * query the configuration as to the Tx Power Policy
+ * to be used on this board, given our desires and
+ * requested power.
+ */
+uint8_t hal_getTxPowerPolicy(
+	u1_t inputPolicy,
+	s1_t requestedPower,
+	u4_t freq
+	);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/lmic/lmic.h
+++ b/src/lmic/lmic.h
@@ -429,7 +429,11 @@ struct lmic_t {
     u1_t        rxsyms;
     u1_t        dndr;
     s1_t        txpow;          // transmit dBm (administrative)
-    s1_t        radio_txpow;    // the radio driver's copy of txpow, limited by adrTxPow.
+    s1_t        radio_txpow;    // the radio driver's copy of txpow, in dB limited by adrTxPow, and
+				// also adjusted for EIRP/antenna gain considerations.
+				// This is just the radio's idea of power. So if you are
+				// controlling EIRP, and you have 3 dB antenna gain, this
+				// needs to reduced by 3 dB.
     s1_t        lbt_dbmax;      // max permissible dB on our channel (eg -80)
 
     u1_t        txChnl;          // channel for next TX

--- a/src/lmic/radio.c
+++ b/src/lmic/radio.c
@@ -424,7 +424,8 @@ static void configLoraModem () {
 
         mc3 = SX1276_MC3_AGCAUTO;
 
-        if ((sf == SF11 || sf == SF12) && bw == BW125) {
+        if ( ((sf == SF11 || sf == SF12) && bw == BW125) ||
+             ((sf == SF12) && bw == BW250) ) {
             mc3 |= SX1276_MC3_LOW_DATA_RATE_OPTIMIZE;
         }
         writeReg(LORARegModemConfig3, mc3);

--- a/src/lmic/radio.c
+++ b/src/lmic/radio.c
@@ -541,7 +541,7 @@ static void configPower () {
 #ifdef CFG_sx1276_radio
     if (req_pw >= 20) {
         policy = LMICHAL_radio_tx_power_policy_20dBm;
-	    eff_pw = 20;
+        eff_pw = 20;
     } else if (req_pw >= 14) {
         policy = LMICHAL_radio_tx_power_policy_paboost;
         if (req_pw > 17) {
@@ -564,7 +564,7 @@ static void configPower () {
     default:
     case LMICHAL_radio_tx_power_policy_rfo:
         rPaDac = SX127X_PADAC_POWER_NORMAL;
-        rOcp = SX127X_OCP_MAtoBITS(50);
+        rOcp = SX127X_OCP_MAtoBITS(80);
 
         if (eff_pw > 14)
             eff_pw = 14;
@@ -572,15 +572,23 @@ static void configPower () {
             // some Semtech code uses this down to eff_pw == 0.
             rPaConfig = eff_pw | SX1276_PAC_MAX_POWER_MASK;
         } else {
+            if (eff_pw < -4)
+                eff_pw = -4;
             rPaConfig = eff_pw + 4;
         }
         break;
 
+    // some radios (HopeRF RFM95W) don't support RFO well,
+    // so the policy might *raise* rfo to paboost. That means
+    // we have to re-check eff_pw, which might be too small.
+    // (And, of course, it might also be too large.)
     case LMICHAL_radio_tx_power_policy_paboost:
         rPaDac = SX127X_PADAC_POWER_NORMAL;
         rOcp = SX127X_OCP_MAtoBITS(100);
         if (eff_pw > 17)
             eff_pw = 17;
+        else if (eff_pw < 2)
+            eff_pw = 2;
         rPaConfig = (eff_pw - 2) | SX1276_PAC_PA_SELECT_PA_BOOST;
         break;
 
@@ -594,7 +602,7 @@ static void configPower () {
 #elif CFG_sx1272_radio
     if (req_pw >= 20) {
         policy = LMICHAL_radio_tx_power_policy_20dBm;
-	    eff_pw = 20;
+            eff_pw = 20;
     } else if (eff_pw >= 14) {
         policy = LMICHAL_radio_tx_power_policy_paboost;
         if (eff_pw > 17) {

--- a/src/lmic/radio.c
+++ b/src/lmic/radio.c
@@ -107,7 +107,9 @@
 #define FSKRegSyncValue6                           0x2D
 #define FSKRegSyncValue7                           0x2E
 #define FSKRegSyncValue8                           0x2F
+#define LORARegIffReq1                             0x2F
 #define FSKRegPacketConfig1                        0x30
+#define LORARegIffReq2                             0x30
 #define FSKRegPacketConfig2                        0x31
 #define LORARegDetectOptimize                      0x31
 #define FSKRegPayloadLength                        0x32
@@ -820,6 +822,18 @@ static void rxlora (u1_t rxmode) {
         writeReg(LORARegInvertIQ, readReg(LORARegInvertIQ)|(1<<6));
     }
 #endif
+
+    // Errata 2.3 - receiver spurious reception of a LoRa signal
+    bw_t const bw = getBw(LMIC.rps);
+    u1_t const rDetectOptimize = readReg(LORARegDetectOptimize);
+    if (bw < BW500) {
+        writeReg(LORARegDetectOptimize, rDetectOptimize & 0x7F);
+        writeReg(LORARegIffReq1, 0x40);
+        writeReg(LORARegIffReq2, 0x40);
+    } else {
+        writeReg(LORARegDetectOptimize, rDetectOptimize | 0x80);
+    }
+
     // set symbol timeout (for single rx)
     writeReg(LORARegSymbTimeoutLsb, LMIC.rxsyms);
     // set sync word

--- a/src/lmic/radio.c
+++ b/src/lmic/radio.c
@@ -318,7 +318,7 @@ static u1_t randbuf[16];
 
 
 #ifdef CFG_sx1276_radio
-#define LNA_RX_GAIN (0x20|0x1)
+#define LNA_RX_GAIN (0x20|0x3)
 #elif CFG_sx1272_radio
 #define LNA_RX_GAIN (0x20|0x03)
 #else

--- a/src/lmic/radio.c
+++ b/src/lmic/radio.c
@@ -773,7 +773,7 @@ static void starttx () {
         oslmic_radio_rssi_t rssi;
         radio_monitor_rssi(LMIC.lbt_ticks, &rssi);
 #if LMIC_X_DEBUG_LEVEL > 0
-	LMIC_X_DEBUG_PRINTF("LBT rssi max:min=%d:%d %d times in %d\n", rssi.max_rssi, rssi.min_rssi, rssi.n_rssi, LMIC.lbt_ticks);
+        LMIC_X_DEBUG_PRINTF("LBT rssi max:min=%d:%d %d times in %d\n", rssi.max_rssi, rssi.min_rssi, rssi.n_rssi, LMIC.lbt_ticks);
 #endif
 
         if (rssi.max_rssi >= LMIC.lbt_dbmax) {
@@ -866,8 +866,8 @@ static void rxlora (u1_t rxmode) {
         hal_waitUntil(LMIC.rxtime); // busy wait until exact rx time
         opmode(OPMODE_RX_SINGLE);
 #if LMIC_DEBUG_LEVEL > 0
-	ostime_t now = os_getTime();
-	LMIC_DEBUG_PRINTF("start single rx: now-rxtime: %"LMIC_PRId_ostime_t"\n", now - LMIC.rxtime);
+        ostime_t now = os_getTime();
+        LMIC_DEBUG_PRINTF("start single rx: now-rxtime: %"LMIC_PRId_ostime_t"\n", now - LMIC.rxtime);
 #endif
     } else { // continous rx (scan or rssi)
         opmode(OPMODE_RX);
@@ -1104,7 +1104,7 @@ void radio_monitor_rssi(ostime_t nTicks, oslmic_radio_rssi_t *pRssi) {
                 rssiMin = rssiNow;
         rssiSum += rssiNow;
         ++rssiN;
-	// TODO(tmm@mcci.com) move this to os_getTime().
+        // TODO(tmm@mcci.com) move this to os_getTime().
         hal_enableIRQs();
         now = os_getTime();
         hal_disableIRQs();
@@ -1159,7 +1159,7 @@ void radio_irq_handler_v2 (u1_t dio, ostime_t now) {
 #endif
     if( (readReg(RegOpMode) & OPMODE_LORA) != 0) { // LORA modem
         u1_t flags = readReg(LORARegIrqFlags);
-	LMIC.saveIrqFlags = flags;
+        LMIC.saveIrqFlags = flags;
         LMIC_X_DEBUG_PRINTF("IRQ=%02x\n", flags);
         if( flags & IRQ_LORA_TXDONE_MASK ) {
             // save exact tx time
@@ -1186,8 +1186,8 @@ void radio_irq_handler_v2 (u1_t dio, ostime_t now) {
             // indicate timeout
             LMIC.dataLen = 0;
 #if LMIC_DEBUG_LEVEL > 0
-	    ostime_t now2 = os_getTime();
-	    LMIC_DEBUG_PRINTF("rxtimeout: entry: %"LMIC_PRId_ostime_t" rxtime: %"LMIC_PRId_ostime_t" entry-rxtime: %"LMIC_PRId_ostime_t" now-entry: %"LMIC_PRId_ostime_t" rxtime-txend: %"LMIC_PRId_ostime_t"\n", entry,
+            ostime_t now2 = os_getTime();
+            LMIC_DEBUG_PRINTF("rxtimeout: entry: %"LMIC_PRId_ostime_t" rxtime: %"LMIC_PRId_ostime_t" entry-rxtime: %"LMIC_PRId_ostime_t" now-entry: %"LMIC_PRId_ostime_t" rxtime-txend: %"LMIC_PRId_ostime_t"\n", entry,
                 LMIC.rxtime, entry - LMIC.rxtime, now2 - entry, LMIC.rxtime-LMIC.txend);
 #endif
         }


### PR DESCRIPTION
This is WIP. We need to test and we need to update README.md.

This patch does the following:

- it refactors the code in `radio.c` `configPower()` to handle transmit power in closer conformance to the SX1272/SX1276 datasheet.  It operates by computing a theoretical power policy (use 20 dBm, use PA_BOOST, or use RFO). It then asks the HAL to inspect the policy and return the actual policy to be used. Finally, it applies the policy.

- it adds a new (optional) feature to the `ArduinoLMIC::HalConfiguration_t` class, `getTxPowerPolicy()`. This is a virtual method, with a supplied default that enforces the policy "PA_BOOST is OK, but 20 dBm is not supported".

- 20 dBm is not supported by default, because we do not have sufficient infrastructure to guarantee the 1% duty cycle required by the datasheet.  However, if the user knows that this isn't a problem, the user may override this.

- The over-current register is set based on the selected transmit power.  This over current protect is really a current limit. We choose a value that allows for some amount of mismatching.  For low power (RFO) modes, we set the current limit to 80 mA; for PA_BOOST, we set to 100 mA; for 20 dBm, we set to 130 mA.  It is possible that we'll want to make this policy driven as well.