### PR TITLE
Fix #328: Added pin mapping for Catena 4617, 4618 and 4630

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -259,12 +259,18 @@ script:
  - _notstm32l0 ||  arduino --verify --board $(_stm32l0opts 'mcci_catena_4610' us915  ) $MCCI_STM32_OPTS $PWD/examples/raw-halconfig/raw-halconfig.ino
  - _notstm32l0 ||  arduino --verify --board $(_stm32l0opts 'mcci_catena_4611' us915  ) $MCCI_STM32_OPTS $PWD/examples/raw-halconfig/raw-halconfig.ino
  - _notstm32l0 ||  arduino --verify --board $(_stm32l0opts 'mcci_catena_4612' us915  ) $MCCI_STM32_OPTS $PWD/examples/raw-halconfig/raw-halconfig.ino
+ - _notstm32l0 ||  arduino --verify --board $(_stm32l0opts 'mcci_catena_4617' us915  ) $MCCI_STM32_OPTS $PWD/examples/raw-halconfig/raw-halconfig.ino
+ - _notstm32l0 ||  arduino --verify --board $(_stm32l0opts 'mcci_catena_4618' us915  ) $MCCI_STM32_OPTS $PWD/examples/raw-halconfig/raw-halconfig.ino
+ - _notstm32l0 ||  arduino --verify --board $(_stm32l0opts 'mcci_catena_4630' us915  ) $MCCI_STM32_OPTS $PWD/examples/raw-halconfig/raw-halconfig.ino
  - _notstm32l0 ||  arduino --verify --board $(_stm32l0opts 'mcci_catena_4801' us915  ) $MCCI_STM32_OPTS $PWD/examples/raw-halconfig/raw-halconfig.ino
 
  - _notstm32l0 ||  { _projcfg COMPILE_REGRESSION_TEST CFG_us915 CFG_sx1276_radio && arduino --verify --board $(_stm32l0opts 'mcci_catena_4551' projcfg) $MCCI_STM32_OPTS $PWD/examples/ttn-otaa-halconfig-us915/ttn-otaa-halconfig-us915.ino ; }
  - _notstm32l0 ||  { _projcfg COMPILE_REGRESSION_TEST CFG_us915 CFG_sx1276_radio && arduino --verify --board $(_stm32l0opts 'mcci_catena_4610' projcfg) $MCCI_STM32_OPTS $PWD/examples/ttn-otaa-halconfig-us915/ttn-otaa-halconfig-us915.ino ; }
  - _notstm32l0 ||  { _projcfg COMPILE_REGRESSION_TEST CFG_us915 CFG_sx1276_radio && arduino --verify --board $(_stm32l0opts 'mcci_catena_4611' projcfg) $MCCI_STM32_OPTS $PWD/examples/ttn-otaa-halconfig-us915/ttn-otaa-halconfig-us915.ino ; }
  - _notstm32l0 ||  { _projcfg COMPILE_REGRESSION_TEST CFG_us915 CFG_sx1276_radio && arduino --verify --board $(_stm32l0opts 'mcci_catena_4612' projcfg) $MCCI_STM32_OPTS $PWD/examples/ttn-otaa-halconfig-us915/ttn-otaa-halconfig-us915.ino ; }
+ - _notstm32l0 ||  { _projcfg COMPILE_REGRESSION_TEST CFG_us915 CFG_sx1276_radio && arduino --verify --board $(_stm32l0opts 'mcci_catena_4617' projcfg) $MCCI_STM32_OPTS $PWD/examples/ttn-otaa-halconfig-us915/ttn-otaa-halconfig-us915.ino ; }
+ - _notstm32l0 ||  { _projcfg COMPILE_REGRESSION_TEST CFG_us915 CFG_sx1276_radio && arduino --verify --board $(_stm32l0opts 'mcci_catena_4618' projcfg) $MCCI_STM32_OPTS $PWD/examples/ttn-otaa-halconfig-us915/ttn-otaa-halconfig-us915.ino ; }
+ - _notstm32l0 ||  { _projcfg COMPILE_REGRESSION_TEST CFG_us915 CFG_sx1276_radio && arduino --verify --board $(_stm32l0opts 'mcci_catena_4630' projcfg) $MCCI_STM32_OPTS $PWD/examples/ttn-otaa-halconfig-us915/ttn-otaa-halconfig-us915.ino ; }
  - _notstm32l0 ||  { _projcfg COMPILE_REGRESSION_TEST CFG_us915 CFG_sx1276_radio && arduino --verify --board $(_stm32l0opts 'mcci_catena_4801' projcfg) $MCCI_STM32_OPTS $PWD/examples/ttn-otaa-halconfig-us915/ttn-otaa-halconfig-us915.ino ; }
 
 

--- a/README.md
+++ b/README.md
@@ -365,14 +365,16 @@ The following boards are pre-integrated.
 - Adafruit [Feather 32u4 LoRa 900 MHz][1] (SX1276)
 - Adafruit [Feather M0 LoRa 900 MHz][2] (SX1276)
 - MCCI Catena 4410, 4420, [4450][3], [4460][4] and [4470][5] boards (based on Adafruit Feather boards plus wings) (SX1276)
-- MCCI Catena [4551][6], 4610, 4611, 4612, and 4801 boards (based on the Murata CMWX1ZZABZ-078 module) (SX1276)
+- MCCI Catena 4551, [4610][6], 4611, [4612][7], 4617, 4618, 4630, and [4801][8] boards (based on the Murata CMWX1ZZABZ-078 module) (SX1276)
 
 [1]: https://www.adafruit.com/products/3078
 [2]: https://www.adafruit.com/products/3178
 [3]: https://store.mcci.com/collections/lorawan-iot-and-the-things-network/products/catena-4450-lorawan-iot-device
 [4]: https://store.mcci.com/collections/lorawan-iot-and-the-things-network/products/catena-4460-sensor-wing-w-bme680
 [5]: https://store.mcci.com/collections/lorawan-iot-and-the-things-network/products/mcci-catena-4470-modbus-node-for-lorawan-technology
-[6]: https://store.mcci.com/collections/lorawan-iot-and-the-things-network/products/catena-4551-integrated-lorawan-node
+[6]: https://store.mcci.com/collections/lorawan-iot-and-the-things-network/products/mcci-catena-4610-integrated-node-for-lorawan-technology 
+[7]: https://store.mcci.com/collections/lorawan-iot-and-the-things-network/products/catena-4612-integrated-lorawan-node 
+[8]: https://store.mcci.com/collections/lorawan-iot-and-the-things-network/products/catena-4801
 
 > To help you know if you have to worry, we'll call such boards "pre-integrated" and prefix each section with suitable guidance.
 

--- a/src/arduino_lmic_hal_boards.h
+++ b/src/arduino_lmic_hal_boards.h
@@ -3,13 +3,20 @@
 Module:  arduino_lmic_hal_boards.h
 
 Function:
-        Arduino-LMIC C++ HAL pinmaps for various boards
+	Arduino-LMIC C++ HAL pinmaps for various boards
 
 Copyright & License:
-        See accompanying LICENSE file.
+	See accompanying LICENSE file.
 
 Author:
-        Terry Moore, MCCI       November 2018
+	Terry Moore, MCCI	November 2018
+
+Revision history:
+   0.6.0  Mon Nov 26 2018 15:06:30  tmm
+	Module created.
+
+   0.7.0  Wed Jun 19 2019 12:29:35  lakshmipriyan
+	Added support for catena 4617 & catena 4618.
 
 */
 

--- a/src/arduino_lmic_hal_boards.h
+++ b/src/arduino_lmic_hal_boards.h
@@ -31,6 +31,8 @@ const HalPinmap_t *GetPinmap_Catena4610();
 const HalPinmap_t *GetPinmap_Catena4610();
 const HalPinmap_t *GetPinmap_Catena4611();
 const HalPinmap_t *GetPinmap_Catena4612();
+const HalPinmap_t *GetPinmap_Catena4617();
+const HalPinmap_t *GetPinmap_Catena4618();
 const HalPinmap_t *GetPinmap_Catena4801();
 
 const HalPinmap_t *GetPinmap_ThisBoard();

--- a/src/arduino_lmic_hal_boards.h
+++ b/src/arduino_lmic_hal_boards.h
@@ -11,13 +11,6 @@ Copyright & License:
 Author:
 	Terry Moore, MCCI	November 2018
 
-Revision history:
-	Mon Nov 26 2018 15:06:30  tmm
-	Module created.
-
-	Wed Jun 19 2019 12:29:35  lakshmipriyan
-	Added support for catena 4617 & catena 4618.
-
 */
 
 #pragma once
@@ -40,6 +33,7 @@ const HalPinmap_t *GetPinmap_Catena4611();
 const HalPinmap_t *GetPinmap_Catena4612();
 const HalPinmap_t *GetPinmap_Catena4617();
 const HalPinmap_t *GetPinmap_Catena4618();
+const HalPinmap_t *GetPinmap_Catena4630();
 const HalPinmap_t *GetPinmap_Catena4801();
 
 const HalPinmap_t *GetPinmap_ThisBoard();

--- a/src/arduino_lmic_hal_boards.h
+++ b/src/arduino_lmic_hal_boards.h
@@ -12,10 +12,10 @@ Author:
 	Terry Moore, MCCI	November 2018
 
 Revision history:
-   0.6.0  Mon Nov 26 2018 15:06:30  tmm
+	Mon Nov 26 2018 15:06:30  tmm
 	Module created.
 
-   0.7.0  Wed Jun 19 2019 12:29:35  lakshmipriyan
+	Wed Jun 19 2019 12:29:35  lakshmipriyan
 	Added support for catena 4617 & catena 4618.
 
 */

--- a/src/arduino_lmic_hal_boards.h
+++ b/src/arduino_lmic_hal_boards.h
@@ -3,13 +3,13 @@
 Module:  arduino_lmic_hal_boards.h
 
 Function:
-	Arduino-LMIC C++ HAL pinmaps for various boards
+        Arduino-LMIC C++ HAL pinmaps for various boards
 
 Copyright & License:
-	See accompanying LICENSE file.
+        See accompanying LICENSE file.
 
 Author:
-	Terry Moore, MCCI	November 2018
+        Terry Moore, MCCI       November 2018
 
 */
 

--- a/src/hal/getconfig_catena4630.cpp
+++ b/src/hal/getconfig_catena4630.cpp
@@ -1,0 +1,103 @@
+/*
+
+Module:  getconfig_catena4630.cpp
+
+Function:
+        Arduino-LMIC C++ HAL pinmaps for various boards
+
+Copyright & License:
+        See accompanying LICENSE file.
+
+Author:
+        Terry Moore, MCCI       November 2018
+
+*/
+
+#if defined(ARDUINO_MCCI_CATENA_4630) || \
+    /* legacy name */ \
+    defined(ARDUINO_CATENA_4630)
+
+#include <arduino_lmic_hal_boards.h>
+#include <Arduino.h>
+
+#include "../lmic/oslmic.h"
+
+namespace Arduino_LMIC {
+
+class HalConfiguration_Catena4630_t : public HalConfiguration_t
+        {
+public:
+        enum DIGITAL_PINS : uint8_t
+                {
+                PIN_SX1276_NSS = D7,
+                PIN_SX1276_NRESET = D8,
+                PIN_SX1276_DIO0 = D25,
+                PIN_SX1276_DIO1 = D26,
+                PIN_SX1276_DIO2 = D27,
+                PIN_SX1276_ANT_SWITCH_RX = D29,
+                PIN_SX1276_ANT_SWITCH_TX_BOOST = D30,
+                PIN_SX1276_ANT_SWITCH_TX_RFO = D31,
+                PIN_VDD_BOOST_ENABLE = A0,
+                PIN_TCXO_VDD = D33,
+                };
+
+        static constexpr ostime_t TCXO_DELAY_MS = 5;
+
+        virtual void begin(void) override
+                {
+                digitalWrite(PIN_TCXO_VDD, 0);
+                pinMode(PIN_TCXO_VDD, OUTPUT);
+                }
+
+        virtual void end(void) override
+                {
+                digitalWrite(PIN_TCXO_VDD, 0);
+                pinMode(PIN_TCXO_VDD, INPUT);
+                }
+
+	virtual bool queryUsingTcxo(void) override { return true; };
+
+        virtual ostime_t setModuleActive(bool state) override
+                {
+                ostime_t result;
+                const int oldState = digitalRead(PIN_TCXO_VDD);
+
+                // if turning on, we need to delay.
+                result = 0;
+                if (state && ! oldState)
+                        result = ms2osticksCeil(TCXO_DELAY_MS);
+
+                if (state != oldState)
+                        digitalWrite(PIN_TCXO_VDD, state);
+
+                return result;
+                }
+        };
+
+// save some typing by bringing the pin numbers into scope
+static HalConfiguration_Catena4630_t myConfig;
+
+static const HalPinmap_t myPinmap =
+        {
+        .nss = HalConfiguration_Catena4630_t::PIN_SX1276_NSS,      // chip select is D7
+        .rxtx = HalConfiguration_Catena4630_t::PIN_SX1276_ANT_SWITCH_RX, // RXTX is D29
+        .rst = HalConfiguration_Catena4630_t::PIN_SX1276_NRESET,   // NRESET is D8
+
+        .dio = {HalConfiguration_Catena4630_t::PIN_SX1276_DIO0,    // DIO0 (IRQ) is D25
+                HalConfiguration_Catena4630_t::PIN_SX1276_DIO1,    // DIO1 is D26
+                HalConfiguration_Catena4630_t::PIN_SX1276_DIO2,    // DIO2 is D27
+               },
+        .rxtx_rx_active = 1,
+        .rssi_cal = 10,
+        .spi_freq = 8000000,     /* 8MHz */
+        .pConfig = &myConfig
+        };
+
+const HalPinmap_t *GetPinmap_Catena4630(void)
+        {
+        return &myPinmap;
+        }
+
+}; // namespace Arduino_LMIC
+
+#endif /* defined(ARDUINO_MCCI_CATENA_4630) || defined(ARDUINO_CATENA_4630) */

--- a/src/hal/getconfig_catena4630.cpp
+++ b/src/hal/getconfig_catena4630.cpp
@@ -9,7 +9,7 @@ Copyright & License:
         See accompanying LICENSE file.
 
 Author:
-        Terry Moore, MCCI       November 2018
+        Dhinesh Kumar Pitchai, MCCI       June 2019
 
 */
 

--- a/src/hal/getpinmap_catena4617.cpp
+++ b/src/hal/getpinmap_catena4617.cpp
@@ -9,7 +9,7 @@ Copyright & License:
         See accompanying LICENSE file.
 
 Author:
-        Terry Moore, MCCI       November 2018
+        Lakshmi Priya Natarajan, MCCI       June 2019
 
 */
 

--- a/src/hal/getpinmap_catena4617.cpp
+++ b/src/hal/getpinmap_catena4617.cpp
@@ -13,9 +13,7 @@ Author:
 
 */
 
-#if defined(ARDUINO_MCCI_CATENA_4617) || \
-    /* legacy name */ \
-    defined(ARDUINO_CATENA_4617)
+#if defined(ARDUINO_MCCI_CATENA_4617)
 
 #include <arduino_lmic_hal_boards.h>
 #include <Arduino.h>

--- a/src/hal/getpinmap_catena4617.cpp
+++ b/src/hal/getpinmap_catena4617.cpp
@@ -1,0 +1,103 @@
+/*
+
+Module:  getconfig_catena4617.cpp
+
+Function:
+        Arduino-LMIC C++ HAL pinmaps for various boards
+
+Copyright & License:
+        See accompanying LICENSE file.
+
+Author:
+        Terry Moore, MCCI       November 2018
+
+*/
+
+#if defined(ARDUINO_MCCI_CATENA_4617) || \
+    /* legacy name */ \
+    defined(ARDUINO_CATENA_4617)
+
+#include <arduino_lmic_hal_boards.h>
+#include <Arduino.h>
+
+#include "../lmic/oslmic.h"
+
+namespace Arduino_LMIC {
+
+class HalConfiguration_Catena4617_t : public HalConfiguration_t
+        {
+public:
+        enum DIGITAL_PINS : uint8_t
+                {
+                PIN_SX1276_NSS = D7,
+                PIN_SX1276_NRESET = D8,
+                PIN_SX1276_DIO0 = D25,
+                PIN_SX1276_DIO1 = D26,
+                PIN_SX1276_DIO2 = D27,
+                PIN_SX1276_ANT_SWITCH_RX = D29,
+                PIN_SX1276_ANT_SWITCH_TX_BOOST = D30,
+                PIN_SX1276_ANT_SWITCH_TX_RFO = D31,
+                PIN_VDD_BOOST_ENABLE = A0,
+                PIN_TCXO_VDD = D33,
+                };
+
+        static constexpr ostime_t TCXO_DELAY_MS = 5;
+
+        virtual void begin(void) override
+                {
+                digitalWrite(PIN_TCXO_VDD, 0);
+                pinMode(PIN_TCXO_VDD, OUTPUT);
+                }
+
+        virtual void end(void) override
+                {
+                digitalWrite(PIN_TCXO_VDD, 0);
+                pinMode(PIN_TCXO_VDD, INPUT);
+                }
+
+	virtual bool queryUsingTcxo(void) override { return true; };
+
+        virtual ostime_t setModuleActive(bool state) override
+                {
+                ostime_t result;
+                const int oldState = digitalRead(PIN_TCXO_VDD);
+
+                // if turning on, we need to delay.
+                result = 0;
+                if (state && ! oldState)
+                        result = ms2osticksCeil(TCXO_DELAY_MS);
+
+                if (state != oldState)
+                        digitalWrite(PIN_TCXO_VDD, state);
+
+                return result;
+                }
+        };
+
+// save some typing by bringing the pin numbers into scope
+static HalConfiguration_Catena4617_t myConfig;
+
+static const HalPinmap_t myPinmap =
+        {
+        .nss = HalConfiguration_Catena4617_t::PIN_SX1276_NSS,      // chip select is D7
+        .rxtx = HalConfiguration_Catena4617_t::PIN_SX1276_ANT_SWITCH_RX, // RXTX is D29
+        .rst = HalConfiguration_Catena4617_t::PIN_SX1276_NRESET,   // NRESET is D8
+
+        .dio = {HalConfiguration_Catena4617_t::PIN_SX1276_DIO0,    // DIO0 (IRQ) is D25
+                HalConfiguration_Catena4617_t::PIN_SX1276_DIO1,    // DIO1 is D26
+                HalConfiguration_Catena4617_t::PIN_SX1276_DIO2,    // DIO2 is D27
+               },
+        .rxtx_rx_active = 1,
+        .rssi_cal = 10,
+        .spi_freq = 8000000,     /* 8MHz */
+        .pConfig = &myConfig
+        };
+
+const HalPinmap_t *GetPinmap_Catena4617(void)
+        {
+        return &myPinmap;
+        }
+
+}; // namespace Arduino_LMIC
+
+#endif /* defined(ARDUINO_MCCI_CATENA_4617) || defined(ARDUINO_CATENA_4617) */

--- a/src/hal/getpinmap_catena4618.cpp
+++ b/src/hal/getpinmap_catena4618.cpp
@@ -9,7 +9,7 @@ Copyright & License:
         See accompanying LICENSE file.
 
 Author:
-        Terry Moore, MCCI       November 2018
+        Lakshmi Priya Natarajan, MCCI       June 2019
 
 */
 

--- a/src/hal/getpinmap_catena4618.cpp
+++ b/src/hal/getpinmap_catena4618.cpp
@@ -13,9 +13,7 @@ Author:
 
 */
 
-#if defined(ARDUINO_MCCI_CATENA_4618) || \
-    /* legacy name */ \
-    defined(ARDUINO_CATENA_4618)
+#if defined(ARDUINO_MCCI_CATENA_4618)
 
 #include <arduino_lmic_hal_boards.h>
 #include <Arduino.h>

--- a/src/hal/getpinmap_catena4618.cpp
+++ b/src/hal/getpinmap_catena4618.cpp
@@ -1,0 +1,103 @@
+/*
+
+Module:  getconfig_catena4618.cpp
+
+Function:
+        Arduino-LMIC C++ HAL pinmaps for various boards
+
+Copyright & License:
+        See accompanying LICENSE file.
+
+Author:
+        Terry Moore, MCCI       November 2018
+
+*/
+
+#if defined(ARDUINO_MCCI_CATENA_4618) || \
+    /* legacy name */ \
+    defined(ARDUINO_CATENA_4618)
+
+#include <arduino_lmic_hal_boards.h>
+#include <Arduino.h>
+
+#include "../lmic/oslmic.h"
+
+namespace Arduino_LMIC {
+
+class HalConfiguration_Catena4618_t : public HalConfiguration_t
+        {
+public:
+        enum DIGITAL_PINS : uint8_t
+                {
+                PIN_SX1276_NSS = D7,
+                PIN_SX1276_NRESET = D8,
+                PIN_SX1276_DIO0 = D25,
+                PIN_SX1276_DIO1 = D26,
+                PIN_SX1276_DIO2 = D27,
+                PIN_SX1276_ANT_SWITCH_RX = D29,
+                PIN_SX1276_ANT_SWITCH_TX_BOOST = D30,
+                PIN_SX1276_ANT_SWITCH_TX_RFO = D31,
+                PIN_VDD_BOOST_ENABLE = A0,
+                PIN_TCXO_VDD = D33,
+                };
+
+        static constexpr ostime_t TCXO_DELAY_MS = 5;
+
+        virtual void begin(void) override
+                {
+                digitalWrite(PIN_TCXO_VDD, 0);
+                pinMode(PIN_TCXO_VDD, OUTPUT);
+                }
+
+        virtual void end(void) override
+                {
+                digitalWrite(PIN_TCXO_VDD, 0);
+                pinMode(PIN_TCXO_VDD, INPUT);
+                }
+
+	virtual bool queryUsingTcxo(void) override { return true; };
+
+        virtual ostime_t setModuleActive(bool state) override
+                {
+                ostime_t result;
+                const int oldState = digitalRead(PIN_TCXO_VDD);
+
+                // if turning on, we need to delay.
+                result = 0;
+                if (state && ! oldState)
+                        result = ms2osticksCeil(TCXO_DELAY_MS);
+
+                if (state != oldState)
+                        digitalWrite(PIN_TCXO_VDD, state);
+
+                return result;
+                }
+        };
+
+// save some typing by bringing the pin numbers into scope
+static HalConfiguration_Catena4618_t myConfig;
+
+static const HalPinmap_t myPinmap =
+        {
+        .nss = HalConfiguration_Catena4618_t::PIN_SX1276_NSS,      // chip select is D7
+        .rxtx = HalConfiguration_Catena4618_t::PIN_SX1276_ANT_SWITCH_RX, // RXTX is D29
+        .rst = HalConfiguration_Catena4618_t::PIN_SX1276_NRESET,   // NRESET is D8
+
+        .dio = {HalConfiguration_Catena4618_t::PIN_SX1276_DIO0,    // DIO0 (IRQ) is D25
+                HalConfiguration_Catena4618_t::PIN_SX1276_DIO1,    // DIO1 is D26
+                HalConfiguration_Catena4618_t::PIN_SX1276_DIO2,    // DIO2 is D27
+               },
+        .rxtx_rx_active = 1,
+        .rssi_cal = 10,
+        .spi_freq = 8000000,     /* 8MHz */
+        .pConfig = &myConfig
+        };
+
+const HalPinmap_t *GetPinmap_Catena4618(void)
+        {
+        return &myPinmap;
+        }
+
+}; // namespace Arduino_LMIC
+
+#endif /* defined(ARDUINO_MCCI_CATENA_4618) || defined(ARDUINO_CATENA_4618) */

--- a/src/hal/getpinmap_catena4630.cpp
+++ b/src/hal/getpinmap_catena4630.cpp
@@ -13,9 +13,7 @@ Author:
 
 */
 
-#if defined(ARDUINO_MCCI_CATENA_4630) || \
-    /* legacy name */ \
-    defined(ARDUINO_CATENA_4630)
+#if defined(ARDUINO_MCCI_CATENA_4630)
 
 #include <arduino_lmic_hal_boards.h>
 #include <Arduino.h>

--- a/src/hal/getpinmap_thisboard.cpp
+++ b/src/hal/getpinmap_thisboard.cpp
@@ -20,7 +20,7 @@ namespace Arduino_LMIC {
 const HalPinmap_t *GetPinmap_ThisBoard(void)
         {
 /*
-|| Adafruit BSPs are not consistent -- m0 express defs ARDUINO_SAMD_FEATHER_M0, 
+|| Adafruit BSPs are not consistent -- m0 express defs ARDUINO_SAMD_FEATHER_M0,
 || m0 defs ADAFRUIT_FEATHER_M0
 */
 #if defined(ARDUINO_SAMD_FEATHER_M0) || defined(ADAFRUIT_FEATHER_M0)
@@ -51,6 +51,8 @@ const HalPinmap_t *GetPinmap_ThisBoard(void)
         return GetPinmap_Catena4617();
 #elif defined(ARDUINO_MCCI_CATENA_4618)
         return GetPinmap_Catena4618();
+#elif defined(ARDUINO_MCCI_CATENA_4630)
+        return GetPinmap_Catena4630();
 #elif defined(ARDUINO_MCCI_CATENA_4801)
         return GetPinmap_Catena4801();
 #elif defined(PINNOCHIO_SCOUT)

--- a/src/hal/getpinmap_thisboard.cpp
+++ b/src/hal/getpinmap_thisboard.cpp
@@ -47,6 +47,10 @@ const HalPinmap_t *GetPinmap_ThisBoard(void)
       /* legacy names */ \
       defined(ARDUINO_CATENA_4612)
         return GetPinmap_Catena4612();
+#elif defined(ARDUINO_MCCI_CATENA_4617)
+        return GetPinmap_Catena4617();
+#elif defined(ARDUINO_MCCI_CATENA_4618)
+        return GetPinmap_Catena4618();
 #elif defined(ARDUINO_MCCI_CATENA_4801)
         return GetPinmap_Catena4801();
 #elif defined(PINNOCHIO_SCOUT)


### PR DESCRIPTION
Added pin mapping for Catena 4617, 4618 and 4630 devices. Also updated travis.yml and README.md for Catena 4617, 4618 and 4630.