### PR TITLE
Fix #333: Emit EV_TXCOMPLETE earlier

### DIFF
--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -1470,7 +1470,6 @@ static void processRx2DnData (xref2osjob_t osjob) {
 
     if( LMIC.dataLen == 0 ) {
         initTxrxFlags(__func__, 0);  // nothing in 1st/2nd DN slot
-        LMIC.txrxFlags = 0;  // nothing in 1st/2nd DN slot
         // It could be that the gateway *is* sending a reply, but we
         // just didn't pick it up. To avoid TX'ing again while the
         // gateay is not listening anyway, delay the next transmission


### PR DESCRIPTION
Before, when no packet was received in RX2, there would be a 3-5 second
delay (for EU868) before calling `processDnData()` and emitting
EV_TXCOMPLETE. This was the `DNW2_SAFETY_ZONE` to prevent a subsequent
TX to collide with a downlink packet that was ongoing but not locked on
to.

With this change, `txDelay()` is used to still delay the subsequent TX,
without delaying the `EV_TXCOMPLETE` event, which allows battery-powered
devices that wait for this event before sleeping to get an extra 3-5
seconds of sleep for each transmitted packet, improving battery life.

Closes: upstream issue 16