### PR TITLE
Fix #385: correct TxSetupParamReq processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1098,7 +1098,8 @@ function uflt12f(rawUflt12)
 
 - HEAD adds the following changes.
 
-  - [#378](https://github.com/mcci-catena/arduino-lmic/pull/378) completely reworks MAC downlink handling. Resulting code passes the LoRaWAN V1.5 EU certification test. (v2.32.2.70)
+  - [#385](https://github.com/mcci-catena/arduino-lmic/issues/385) corrects an error handling data rate selection for `TxParamSetupReq`, found in US-915 certification testing. (v2.3.2.71)
+  - [#378](https://github.com/mcci-catena/arduino-lmic/pull/378) completely reworks MAC downlink handling. Resulting code passes the LoRaWAN V1.5 EU certification test. (v2.3.2.70)
   - [#360](https://github.com/mcci-catena/arduino-lmic/pull/360) adds support for the KR-920 regional plan.
 
 - v2.3.2 is a patch release. It incorporates two pull requests.

--- a/examples/compliance-otaa-halconfig/compliance-otaa-halconfig.ino
+++ b/examples/compliance-otaa-halconfig/compliance-otaa-halconfig.ino
@@ -225,6 +225,13 @@ const char *getCrcName(rps_t rps) {
     return getNocrc(rps) ? "NoCrc" : "Crc";
 }
 
+void printHex2(unsigned v) {
+    v &= 0xff;
+    if (v < 16)
+        Serial.print('0');
+    Serial.print(v, HEX);
+}
+
 void printFreq(u4_t freq) {
     Serial.print(F(": freq="));
     Serial.print(freq / 1000000);
@@ -233,13 +240,13 @@ void printFreq(u4_t freq) {
 }
 
 void printRps(rps_t rps) {
-    Serial.print(F(" rps=0x")); Serial.print(unsigned(rps), HEX);
+    Serial.print(F(" rps=0x")); printHex2(rps);
     Serial.print(F(" (")); Serial.print(getSfName(rps));
     Serial.print(F(" ")); Serial.print(getBwName(rps));
     Serial.print(F(" ")); Serial.print(getCrName(rps));
     Serial.print(F(" ")); Serial.print(getCrcName(rps));
     Serial.print(F(" IH=")); Serial.print(unsigned(getIh(rps)));
-    Serial.print(F(")"));
+    Serial.print(')');
 }
 
 void printOpmode(uint16_t opmode, char sep = ',') {
@@ -261,18 +268,18 @@ void printDatarate(u1_t datarate) {
     Serial.print(F(", datarate=")); Serial.print(unsigned(datarate));
 }
 
-void printTxrxflags(u2_t txrxFlags) {
-    Serial.print(F(", txrxFlags=0x")); Serial.print(unsigned(txrxFlags), HEX);
+void printTxrxflags(u1_t txrxFlags) {
+    Serial.print(F(", txrxFlags=0x")); printHex2(txrxFlags);
     if (txrxFlags & TXRX_ACK)
         Serial.print(F("; Received ack"));
 }
 
 void printSaveIrqFlags(u1_t saveIrqFlags) {
     Serial.print(F(", saveIrqFlags 0x"));
-    Serial.print(unsigned(saveIrqFlags), HEX);
+    printHex2(saveIrqFlags);
 }
 
-// dump all the registers.
+// dump all the registers.  Must have printf setup.
 void printAllRegisters(void) {
     uint8_t regbuf[0x80];
     regbuf[0] = 0;
@@ -280,9 +287,11 @@ void printAllRegisters(void) {
 
     for (unsigned i = 0; i < sizeof(regbuf); ++i) {
         if (i % 16 == 0) {
-            printf("\r\n%02x:", i);
+            printNl();
+            printHex2(i);
         }
-        printf("%s%02x", ((i % 16) == 8) ? " - " : " ", regbuf[i]);
+        printHex2(regbuf[i]);
+        Serial.print(((i % 16) == 8) ? F(" - ") : F(" "));
     }
 
     // reset the radio, just in case the register dump caused issues.
@@ -297,7 +306,7 @@ void printAllRegisters(void) {
 }
 
 void printNl(void) {
-    Serial.println("");
+    Serial.println();
 }
 
 void eventPrint(cEventQueue::eventnode_t &e) {
@@ -322,7 +331,7 @@ void eventPrint(cEventQueue::eventnode_t &e) {
         printTxChnl(e.txChnl);
         printRps(e.rps);
         printOpmode(e.opmode);
-        printTxrxflags(e.opmode);
+        printTxrxflags(e.txrxFlags);
         printSaveIrqFlags(e.saveIrqFlags);
         printAllRegisters();
     } else {
@@ -360,15 +369,15 @@ void eventPrint(cEventQueue::eventnode_t &e) {
                     Serial.print("artKey: ");
                     for (int i=0; i<sizeof(artKey); ++i) {
                         if (i != 0)
-                        Serial.print("-");
-                        Serial.print(artKey[i], HEX);
+                            Serial.print("-");
+                        printHex2(artKey[i]);
                     }
                     Serial.println("");
                     Serial.print("nwkKey: ");
                     for (int i=0; i<sizeof(nwkKey); ++i) {
                             if (i != 0)
                                     Serial.print("-");
-                            Serial.print(nwkKey[i], HEX);
+                            printHex2(nwkKey[i]);
                     }
                 } while (0);
                 break;
@@ -503,7 +512,7 @@ void myRxMessageCb(
             if (port == LORAWAN_PORT_COMPLIANCE) {
                 Serial.print(F("Received test packet 0x"));
                 if (nMessage > 0)
-                    Serial.print(pMessage[0], HEX);
+                    printHex2(pMessage[0]);
                 Serial.print(F(" length "));
                 Serial.println((unsigned) nMessage);
             }
@@ -607,14 +616,11 @@ void setup() {
     do_send(&sendjob);
 }
 
-void setup_printSignOnDashes(void)
+void setup_printSignOnDashLine(void)
     {
-    Serial.print(F("------------------------------------"));
-    }
-void setup_printSignOnDashLine()
-    {
-    setup_printSignOnDashes();
-    setup_printSignOnDashes();
+    for (unsigned i = 0; i < 78; ++i)
+        Serial.print('-');
+
     printNl();
     }
 
@@ -656,7 +662,7 @@ void setup_printSignOn()
     printVersion(ARDUINO_LMIC_VERSION);
     Serial.print(F(" configured for region "));
     Serial.print(CFG_region);
-    Serial.println(F("."));
+    Serial.println('.');
     Serial.println(F("Remember to select 'Line Ending: Newline' at the bottom of the monitor window."));
 
     setup_printSignOnDashLine();

--- a/examples/compliance-otaa-halconfig/compliance-otaa-halconfig.ino
+++ b/examples/compliance-otaa-halconfig/compliance-otaa-halconfig.ino
@@ -665,7 +665,7 @@ void setup_printSignOn()
 
 void setupForNetwork(bool preJoin) {
 #if defined(CFG_us915)
-    LMIC_selectSubBand(1);
+    LMIC_selectSubBand(0);
 
     if (! preJoin) {
 //        LMIC_setLinkCheckMode(0);

--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -761,6 +761,17 @@ applyAdrRequests(
 
     if (! map_ok) {
         adrAns &= ~MCMD_LinkADRAns_ChannelACK;
+    }
+
+    // p1 now has txpow + DR. DR must be feasible.
+    dr_t dr = (dr_t)(p1>>MCMD_LinkADRReq_DR_SHIFT);
+
+    if (adrAns == (MCMD_LinkADRAns_PowerACK | MCMD_LinkADRAns_DataRateACK | MCMD_LinkADRAns_ChannelACK) && ! LMICbandplan_isDataRateFeasible(dr)) {
+        adrAns &= ~MCMD_LinkADRAns_DataRateACK;
+        LMICOS_logEventUint32("applyAdrRequests: final DR not feasible", dr);
+    }
+
+    if (adrAns != (MCMD_LinkADRAns_PowerACK | MCMD_LinkADRAns_DataRateACK | MCMD_LinkADRAns_ChannelACK)) {
         LMICbandplan_restoreAdrState(&initialState);
     }
 
@@ -785,8 +796,6 @@ applyAdrRequests(
             LMIC.upRepeat = uprpt;
             changes = 1;
         }
-
-        dr_t dr = (dr_t)(p1>>MCMD_LinkADRReq_DR_SHIFT);
 
         LMICOS_logEventUint32("applyAdrRequests: setDrTxPow", (adrAns << 16)|(dr << 8)|(p1 << 0));
 

--- a/src/lmic/lmic.h
+++ b/src/lmic/lmic.h
@@ -105,7 +105,7 @@ extern "C"{
 #define ARDUINO_LMIC_VERSION_CALC(major, minor, patch, local)	\
 	(((major) << 24u) | ((minor) << 16u) | ((patch) << 8u) | (local))
 
-#define	ARDUINO_LMIC_VERSION	ARDUINO_LMIC_VERSION_CALC(2, 3, 2, 70)	/* v2.3.2.70 */
+#define	ARDUINO_LMIC_VERSION	ARDUINO_LMIC_VERSION_CALC(2, 3, 2, 71)	/* v2.3.2.71 */
 
 #define	ARDUINO_LMIC_VERSION_GET_MAJOR(v)	\
 	(((v) >> 24u) & 0xFFu)

--- a/src/lmic/lmic_bandplan.h
+++ b/src/lmic/lmic_bandplan.h
@@ -162,6 +162,10 @@
 # error "LMICbandplan_restoreAdrState() not defined by bandplan"
 #endif
 
+#if !defined(LMICbandplan_isDataRateFeasible)
+# error "LMICbandplan_isDataRateFeasible() not defined by bandplan"
+#endif
+
 //
 // Things common to lmic.c code
 //

--- a/src/lmic/lmic_eu_like.c
+++ b/src/lmic/lmic_eu_like.c
@@ -108,6 +108,15 @@ bit_t LMICeulike_mapChannels(u1_t chpage, u2_t chmap) {
     return LMIC.channelMap != 0;
 }
 
+bit_t LMICeulike_isDataRateFeasible(dr_t dr) {
+        for (u1_t chnl = 0; chnl < MAX_CHANNELS; ++chnl) {
+                if ((LMIC.channelMap & (1 << chnl)) != 0 &&  // channel enabled
+                        (LMIC.channelDrMap[chnl] & (1 << dr)) != 0)
+                                return 1;
+        }
+        return 0;
+}
+
 #if !defined(DISABLE_JOIN)
 void LMICeulike_initJoinLoop(uint8_t nDefaultChannels, s1_t adrTxPow) {
 #if CFG_TxContinuousMode

--- a/src/lmic/lmic_eu_like.h
+++ b/src/lmic/lmic_eu_like.h
@@ -107,4 +107,8 @@ void LMICeulike_restoreAdrState(const lmic_saved_adr_state_t *pStateBuffer);
 // set Rx1 frequency (might be different than uplink).
 void LMICeulike_setRx1Freq(void);
 
+bit_t LMICeulike_isDataRateFeasible(dr_t dr);
+#define LMICbandplan_isDataRateFeasible(dr) LMICeulike_isDataRateFeasible(dr)
+
+
 #endif // _lmic_eu_like_h_

--- a/src/lmic/lmic_us_like.h
+++ b/src/lmic/lmic_us_like.h
@@ -109,4 +109,7 @@ bit_t LMICuslike_compareAdrState(const lmic_saved_adr_state_t *pStateBuffer);
 void LMICuslike_restoreAdrState(const lmic_saved_adr_state_t *pStateBuffer);
 #define LMICbandplan_restoreAdrState(pState) LMICuslike_restoreAdrState(pState)
 
+bit_t LMICuslike_isDataRateFeasible(dr_t dr);
+#define LMICbandplan_isDataRateFeasible(dr) LMICuslike_isDataRateFeasible(dr)
+
 #endif // _lmic_us_like_h_


### PR DESCRIPTION
See bug report #385. Also, fix #386: change compliance sketch to use subband 0 for testing in the US, and slim it down enough that a Class A version can build and run in all regions.