### PR TITLE
bugfix: add missing pinmode initialization in hal_interrupt_init()

### DIFF
--- a/src/hal/hal.cpp
+++ b/src/hal/hal.cpp
@@ -130,6 +130,7 @@ static void hal_interrupt_init() {
       if (plmic_pins->dio[i] == LMIC_UNUSED_PIN)
           continue;
 
+      pinMode(plmic_pins->dio[i], INPUT);
       attachInterrupt(digitalPinToInterrupt(plmic_pins->dio[i]), interrupt_fns[i], RISING);
   }
 }


### PR DESCRIPTION
Pinmode initialization is missing in hal_interrupt_init() for the interrupt driven timestamping mode.
Without pinmode initialization the interrupt driven timestamping mode does not work (tested on ESP32 hardware). Added just this one extra line and heureka it worked! :-)