### PR TITLE
Bump Arduino IDE version to 1.8.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ sudo: true
 
 env:
  global:
-  - IDE_VERSION=1.8.9
+  - IDE_VERSION=1.8.10
  matrix:
   - TARGET=samd
   - TARGET=stm32l0


### PR DESCRIPTION
Release notes for Arduino IDE 1.8.10 are found [here](https://www.arduino.cc/en/Main/ReleaseNotes).