### PR TITLE
Rename au921 to au915

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -139,7 +139,7 @@ script:
  # make sure the compliance sketch compiles on AVR in all regions.
  - _notesp32 ||  { _projcfg CFG_us915   CFG_sx1276_radio && arduino --verify --board $(_esp32opts '' projcfg) $PWD/examples/compliance-otaa-halconfig/compliance-otaa-halconfig.ino ; }
  - _notesp32 ||  { _projcfg CFG_eu868   CFG_sx1276_radio && arduino --verify --board $(_esp32opts '' projcfg) $PWD/examples/compliance-otaa-halconfig/compliance-otaa-halconfig.ino ; }
- - _notesp32 ||  { _projcfg CFG_au921   CFG_sx1276_radio && arduino --verify --board $(_esp32opts '' projcfg) $PWD/examples/compliance-otaa-halconfig/compliance-otaa-halconfig.ino ; }
+ - _notesp32 ||  { _projcfg CFG_au915   CFG_sx1276_radio && arduino --verify --board $(_esp32opts '' projcfg) $PWD/examples/compliance-otaa-halconfig/compliance-otaa-halconfig.ino ; }
  - _notesp32 ||  { _projcfg CFG_as923   CFG_sx1276_radio && arduino --verify --board $(_esp32opts '' projcfg) $PWD/examples/compliance-otaa-halconfig/compliance-otaa-halconfig.ino ; }
  - _notesp32 ||  { _projcfg CFG_as923jp CFG_sx1276_radio && arduino --verify --board $(_esp32opts '' projcfg) $PWD/examples/compliance-otaa-halconfig/compliance-otaa-halconfig.ino ; }
  - _notesp32 ||  { _projcfg CFG_kr920   CFG_sx1276_radio && arduino --verify --board $(_esp32opts '' projcfg) $PWD/examples/compliance-otaa-halconfig/compliance-otaa-halconfig.ino ; }
@@ -151,7 +151,7 @@ script:
  #
  - _notavr ||  { _projcfg COMPILE_REGRESSION_TEST CFG_us915   CFG_sx1276_radio && arduino --verify --board $(_avropts) $PWD/examples/ttn-otaa-feather-us915/ttn-otaa-feather-us915.ino ; }
 #- _notavr ||  { _projcfg COMPILE_REGRESSION_TEST CFG_eu868   CFG_sx1276_radio && arduino --verify --board $(_avropts) $PWD/examples/ttn-otaa-feather-us915/ttn-otaa-feather-us915.ino ; }
- - _notavr ||  { _projcfg COMPILE_REGRESSION_TEST CFG_au921   CFG_sx1276_radio && arduino --verify --board $(_avropts) $PWD/examples/ttn-otaa-feather-us915/ttn-otaa-feather-us915.ino ; }
+ - _notavr ||  { _projcfg COMPILE_REGRESSION_TEST CFG_au915   CFG_sx1276_radio && arduino --verify --board $(_avropts) $PWD/examples/ttn-otaa-feather-us915/ttn-otaa-feather-us915.ino ; }
 #- _notavr ||  { _projcfg COMPILE_REGRESSION_TEST CFG_as923   CFG_sx1276_radio && arduino --verify --board $(_avropts) $PWD/examples/ttn-otaa-feather-us915/ttn-otaa-feather-us915.ino ; }
 #- _notavr ||  { _projcfg COMPILE_REGRESSION_TEST CFG_as923jp CFG_sx1276_radio && arduino --verify --board $(_avropts) $PWD/examples/ttn-otaa-feather-us915/ttn-otaa-feather-us915.ino ; }
 #- _notavr ||  { _projcfg COMPILE_REGRESSION_TEST CFG_kr920   CFG_sx1276_radio && arduino --verify --board $(_avropts) $PWD/examples/ttn-otaa-feather-us915/ttn-otaa-feather-us915.ino ; }
@@ -159,7 +159,7 @@ script:
 
  - _notavr ||  { _projcfg COMPILE_REGRESSION_TEST CFG_us915   CFG_sx1276_radio && arduino --verify --board $(_avropts) $PWD/examples/raw-feather/raw-feather.ino ; }
  - _notavr ||  { _projcfg COMPILE_REGRESSION_TEST CFG_eu868   CFG_sx1276_radio && arduino --verify --board $(_avropts) $PWD/examples/raw-feather/raw-feather.ino ; }
- - _notavr ||  { _projcfg COMPILE_REGRESSION_TEST CFG_au921   CFG_sx1276_radio && arduino --verify --board $(_avropts) $PWD/examples/raw-feather/raw-feather.ino ; }
+ - _notavr ||  { _projcfg COMPILE_REGRESSION_TEST CFG_au915   CFG_sx1276_radio && arduino --verify --board $(_avropts) $PWD/examples/raw-feather/raw-feather.ino ; }
  - _notavr ||  { _projcfg COMPILE_REGRESSION_TEST CFG_as923   CFG_sx1276_radio && arduino --verify --board $(_avropts) $PWD/examples/raw-feather/raw-feather.ino ; }
  - _notavr ||  { _projcfg COMPILE_REGRESSION_TEST CFG_as923jp CFG_sx1276_radio && arduino --verify --board $(_avropts) $PWD/examples/raw-feather/raw-feather.ino ; }
  - _notavr ||  { _projcfg COMPILE_REGRESSION_TEST CFG_kr920   CFG_sx1276_radio && arduino --verify --board $(_avropts) $PWD/examples/raw-feather/raw-feather.ino ; }
@@ -169,7 +169,7 @@ script:
  # unfortunately EU currently is a little too large, so we don't do EU.
  - _notavr ||  { _projcfg_class_a CFG_us915   CFG_sx1276_radio && arduino --verify --board $(_avropts) $PWD/examples/compliance-otaa-halconfig/compliance-otaa-halconfig.ino ; }
  # - _notavr ||  { _projcfg_class_a CFG_eu868   CFG_sx1276_radio && arduino --verify --board $(_avropts) $PWD/examples/compliance-otaa-halconfig/compliance-otaa-halconfig.ino ; }
- - _notavr ||  { _projcfg_class_a CFG_au921   CFG_sx1276_radio && arduino --verify --board $(_avropts) $PWD/examples/compliance-otaa-halconfig/compliance-otaa-halconfig.ino ; }
+ - _notavr ||  { _projcfg_class_a CFG_au915   CFG_sx1276_radio && arduino --verify --board $(_avropts) $PWD/examples/compliance-otaa-halconfig/compliance-otaa-halconfig.ino ; }
  - _notavr ||  { _projcfg_class_a CFG_as923   CFG_sx1276_radio && arduino --verify --board $(_avropts) $PWD/examples/compliance-otaa-halconfig/compliance-otaa-halconfig.ino ; }
  - _notavr ||  { _projcfg_class_a CFG_as923jp CFG_sx1276_radio && arduino --verify --board $(_avropts) $PWD/examples/compliance-otaa-halconfig/compliance-otaa-halconfig.ino ; }
  - _notavr ||  { _projcfg_class_a CFG_kr920   CFG_sx1276_radio && arduino --verify --board $(_avropts) $PWD/examples/compliance-otaa-halconfig/compliance-otaa-halconfig.ino ; }
@@ -192,7 +192,7 @@ script:
  - _notsamd || arduino --verify --board $(_samdopts '' eu868) $PWD/examples/raw-feather/raw-feather.ino
 # V1.1.0 of the samd bsp doesn't support au915 correctly -- test with projcfg
 #- arduino --verify --board $(_samdopts '' au915) $PWD/examples/raw-feather/raw-feather.ino
- - _notsamd || { _projcfg CFG_au921 CFG_sx1276_radio && arduino --verify --board $(_samdopts '' projcfg) $PWD/examples/raw-feather/raw-feather.ino ; }
+ - _notsamd || { _projcfg CFG_au915 CFG_sx1276_radio && arduino --verify --board $(_samdopts '' projcfg) $PWD/examples/raw-feather/raw-feather.ino ; }
  - _notsamd || arduino --verify --board $(_samdopts '' as923) $PWD/examples/raw-feather/raw-feather.ino
  - _notsamd || arduino --verify --board $(_samdopts '' as923jp) $PWD/examples/raw-feather/raw-feather.ino
 # V2.0.0 of the samd bsp doesn't include kr920 support in menus, use projcfg
@@ -210,7 +210,7 @@ script:
 # test ttn-otaa-feather-us915 in all relevant regions with sx1276
  - _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_us915   CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-otaa-feather-us915/ttn-otaa-feather-us915.ino ; }
 #- _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_eu868   CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-otaa-feather-us915/ttn-otaa-feather-us915.ino ; }
- - _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_au921   CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-otaa-feather-us915/ttn-otaa-feather-us915.ino ; }
+ - _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_au915   CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-otaa-feather-us915/ttn-otaa-feather-us915.ino ; }
 #- _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_as923   CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-otaa-feather-us915/ttn-otaa-feather-us915.ino ; }
 #- _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_as923jp CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-otaa-feather-us915/ttn-otaa-feather-us915.ino ; }
 #- _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_kr920   CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-otaa-feather-us915/ttn-otaa-feather-us915.ino ; }
@@ -229,7 +229,7 @@ script:
 # test ttn-otaa with all regions
  - _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_us915   CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-otaa/ttn-otaa.ino ; }
  - _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_eu868   CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-otaa/ttn-otaa.ino ; }
- - _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_au921   CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-otaa/ttn-otaa.ino ; }
+ - _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_au915   CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-otaa/ttn-otaa.ino ; }
  - _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_as923   CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-otaa/ttn-otaa.ino ; }
  - _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_as923jp CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-otaa/ttn-otaa.ino ; }
  - _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_kr920   CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-otaa/ttn-otaa.ino ; }
@@ -238,7 +238,7 @@ script:
 # test ttn-abp with all regions
  - _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_us915   CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-abp/ttn-abp.ino ; }
  - _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_eu868   CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-abp/ttn-abp.ino ; }
- - _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_au921   CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-abp/ttn-abp.ino ; }
+ - _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_au915   CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-abp/ttn-abp.ino ; }
  - _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_as923   CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-abp/ttn-abp.ino ; }
  - _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_as923jp CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-abp/ttn-abp.ino ; }
  - _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_kr920   CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-abp/ttn-abp.ino ; }
@@ -247,7 +247,7 @@ script:
 # test ttn-otaa-feather-us915-dht22 in all relevant regions with sx1276
  - _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_us915   CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-otaa-feather-us915-dht22/ttn-otaa-feather-us915-dht22.ino ; }
 #- _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_eu868   CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-otaa-feather-us915-dht22/ttn-otaa-feather-us915-dht22.ino ; }
- - _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_au921   CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-otaa-feather-us915-dht22/ttn-otaa-feather-us915-dht22.ino ; }
+ - _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_au915   CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-otaa-feather-us915-dht22/ttn-otaa-feather-us915-dht22.ino ; }
 #- _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_as923   CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-otaa-feather-us915-dht22/ttn-otaa-feather-us915-dht22.ino ; }
 #- _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_as923jp CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-otaa-feather-us915-dht22/ttn-otaa-feather-us915-dht22.ino ; }
 #- _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_kr920   CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-otaa-feather-us915-dht22/ttn-otaa-feather-us915-dht22.ino ; }
@@ -256,7 +256,7 @@ script:
 # test ttn-abp-feather-us915-dht22 in all relevant regions with sx1276
  - _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_us915   CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-abp-feather-us915-dht22/ttn-abp-feather-us915-dht22.ino ; }
 #- _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_eu868   CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-abp-feather-us915-dht22/ttn-abp-feather-us915-dht22.ino ; }
- - _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_au921   CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-abp-feather-us915-dht22/ttn-abp-feather-us915-dht22.ino ; }
+ - _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_au915   CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-abp-feather-us915-dht22/ttn-abp-feather-us915-dht22.ino ; }
 #- _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_as923   CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-abp-feather-us915-dht22/ttn-abp-feather-us915-dht22.ino ; }
 #- _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_as923jp CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-abp-feather-us915-dht22/ttn-abp-feather-us915-dht22.ino ; }
 #- _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_kr920   CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-abp-feather-us915-dht22/ttn-abp-feather-us915-dht22.ino ; }
@@ -265,7 +265,7 @@ script:
 # test ttn-otaa-network-time in all regions
  - _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_us915   CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-otaa-network-time/ttn-otaa-network-time.ino ; }
  - _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_eu868   CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-otaa-network-time/ttn-otaa-network-time.ino ; }
- - _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_au921   CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-otaa-network-time/ttn-otaa-network-time.ino ; }
+ - _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_au915   CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-otaa-network-time/ttn-otaa-network-time.ino ; }
  - _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_as923   CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-otaa-network-time/ttn-otaa-network-time.ino ; }
  - _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_as923jp CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-otaa-network-time/ttn-otaa-network-time.ino ; }
  - _notsamd || { _projcfg COMPILE_REGRESSION_TEST CFG_kr920   CFG_sx1276_radio && arduino --verify --board mcci:samd:mcci_catena_4450:lorawan_region=projcfg $PWD/examples/ttn-otaa-network-time/ttn-otaa-network-time.ino ; }

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ requires C99 mode to be enabled by default.
 - [Configuration](#configuration)
 	- [Selecting the LoRaWAN Region Configuration](#selecting-the-lorawan-region-configuration)
 		- [eu868, as923, in866, kr920](#eu868-as923-in866-kr920)
-		- [us915, au921](#us915-au921)
+		- [us915, au915](#us915-au915)
 	- [Selecting the target radio transceiver](#selecting-the-target-radio-transceiver)
 	- [Controlling use of interrupts](#controlling-use-of-interrupts)
 	- [Disabling PING](#disabling-ping)
@@ -200,7 +200,7 @@ The library supports the following regions:
 ------------|-----------------|:----------------:|:-------------------:|--------
 `-D CFG_eu868` | `LMIC_REGION_eu868` | 1 | 2.2 | EU 863-870 MHz ISM
 `-D CFG_us915` | `LMIC_REGION_us915` | 2 | 2.3 | US 902-928 MHz ISM
-`-D CFG_au921` | `LMIC_REGION_au921` | 5 | 2.6 | Australia 915-928 MHz ISM
+`-D CFG_au915` | `LMIC_REGION_au915` | 5 | 2.6 | Australia 915-928 MHz ISM
 `-D CFG_as923` | `LMIC_REGION_as923` | 7 | 2.8 | Asia 923 MHz ISM
 `-D CFG_as923jp` | `LMIC_REGION_as923` and `LMIC_COUNTRY_CODE_JP` | 7 | 2.8 | Asia 923 MHz ISM with Japan listen-before-talk (LBT) rules
 `-D CFG_kr920` | `LMIC_REGION_kr920` | 8 | 2.9 | Korea 920-923 MHz ISM
@@ -221,7 +221,7 @@ the following changes:
 - Add the constants `MAX_CHANNELS`, `MAX_BANDS`, `LIMIT_CHANNELS`, `BAND_MILLI`,
 `BAND_CENTI`, `BAND_DECI`, and `BAND_AUX`.
 
-#### us915, au921
+#### us915, au915
 
 If the library is configured for US915 operation, we make the following changes:
 

--- a/ci/platformio.sh
+++ b/ci/platformio.sh
@@ -38,7 +38,7 @@ then
     # Compile "ttn-otaa" example in all regions
     PLATFORMIO_BUILD_FLAGS='-D CFG_us915   -D CFG_sx1276_radio -D COMPILE_REGRESSION_TEST -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS' platformio ci --lib . --board heltec_wifi_lora_32 'examples/ttn-otaa/ttn-otaa.ino'
     PLATFORMIO_BUILD_FLAGS='-D CFG_eu868   -D CFG_sx1276_radio -D COMPILE_REGRESSION_TEST -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS' platformio ci --lib . --board heltec_wifi_lora_32 'examples/ttn-otaa/ttn-otaa.ino'
-    PLATFORMIO_BUILD_FLAGS='-D CFG_au921   -D CFG_sx1276_radio -D COMPILE_REGRESSION_TEST -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS' platformio ci --lib . --board heltec_wifi_lora_32 'examples/ttn-otaa/ttn-otaa.ino'
+    PLATFORMIO_BUILD_FLAGS='-D CFG_au915   -D CFG_sx1276_radio -D COMPILE_REGRESSION_TEST -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS' platformio ci --lib . --board heltec_wifi_lora_32 'examples/ttn-otaa/ttn-otaa.ino'
     PLATFORMIO_BUILD_FLAGS='-D CFG_as923   -D CFG_sx1276_radio -D COMPILE_REGRESSION_TEST -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS' platformio ci --lib . --board heltec_wifi_lora_32 'examples/ttn-otaa/ttn-otaa.ino'
     PLATFORMIO_BUILD_FLAGS='-D CFG_as923jp -D CFG_sx1276_radio -D COMPILE_REGRESSION_TEST -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS' platformio ci --lib . --board heltec_wifi_lora_32 'examples/ttn-otaa/ttn-otaa.ino'
     PLATFORMIO_BUILD_FLAGS='-D CFG_kr920   -D CFG_sx1276_radio -D COMPILE_REGRESSION_TEST -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS' platformio ci --lib . --board heltec_wifi_lora_32 'examples/ttn-otaa/ttn-otaa.ino'
@@ -47,7 +47,7 @@ then
     # Compile "ttn-abp" example in all regions
     PLATFORMIO_BUILD_FLAGS='-D CFG_us915   -D CFG_sx1276_radio -D COMPILE_REGRESSION_TEST -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS' platformio ci --lib . --board heltec_wifi_lora_32 'examples/ttn-abp/ttn-abp.ino'
     PLATFORMIO_BUILD_FLAGS='-D CFG_eu868   -D CFG_sx1276_radio -D COMPILE_REGRESSION_TEST -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS' platformio ci --lib . --board heltec_wifi_lora_32 'examples/ttn-abp/ttn-abp.ino'
-    PLATFORMIO_BUILD_FLAGS='-D CFG_au921   -D CFG_sx1276_radio -D COMPILE_REGRESSION_TEST -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS' platformio ci --lib . --board heltec_wifi_lora_32 'examples/ttn-abp/ttn-abp.ino'
+    PLATFORMIO_BUILD_FLAGS='-D CFG_au915   -D CFG_sx1276_radio -D COMPILE_REGRESSION_TEST -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS' platformio ci --lib . --board heltec_wifi_lora_32 'examples/ttn-abp/ttn-abp.ino'
     PLATFORMIO_BUILD_FLAGS='-D CFG_as923   -D CFG_sx1276_radio -D COMPILE_REGRESSION_TEST -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS' platformio ci --lib . --board heltec_wifi_lora_32 'examples/ttn-abp/ttn-abp.ino'
     PLATFORMIO_BUILD_FLAGS='-D CFG_as923jp -D CFG_sx1276_radio -D COMPILE_REGRESSION_TEST -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS' platformio ci --lib . --board heltec_wifi_lora_32 'examples/ttn-abp/ttn-abp.ino'
     PLATFORMIO_BUILD_FLAGS='-D CFG_kr920   -D CFG_sx1276_radio -D COMPILE_REGRESSION_TEST -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS' platformio ci --lib . --board heltec_wifi_lora_32 'examples/ttn-abp/ttn-abp.ino'
@@ -56,7 +56,7 @@ then
     # Compile "ttn-otaa-network-time" example in all regions
     PLATFORMIO_BUILD_FLAGS='-D CFG_us915   -D CFG_sx1276_radio -D LMIC_ENABLE_DeviceTimeReq=1 -D COMPILE_REGRESSION_TEST -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS' platformio ci --project-option="lib_deps=Time" --lib . --board heltec_wifi_lora_32 'examples/ttn-otaa-network-time/ttn-otaa-network-time.ino'
     PLATFORMIO_BUILD_FLAGS='-D CFG_eu868   -D CFG_sx1276_radio -D LMIC_ENABLE_DeviceTimeReq=1 -D COMPILE_REGRESSION_TEST -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS' platformio ci --project-option="lib_deps=Time" --lib . --board heltec_wifi_lora_32 'examples/ttn-otaa-network-time/ttn-otaa-network-time.ino'
-    PLATFORMIO_BUILD_FLAGS='-D CFG_au921   -D CFG_sx1276_radio -D LMIC_ENABLE_DeviceTimeReq=1 -D COMPILE_REGRESSION_TEST -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS' platformio ci --project-option="lib_deps=Time" --lib . --board heltec_wifi_lora_32 'examples/ttn-otaa-network-time/ttn-otaa-network-time.ino'
+    PLATFORMIO_BUILD_FLAGS='-D CFG_au915   -D CFG_sx1276_radio -D LMIC_ENABLE_DeviceTimeReq=1 -D COMPILE_REGRESSION_TEST -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS' platformio ci --project-option="lib_deps=Time" --lib . --board heltec_wifi_lora_32 'examples/ttn-otaa-network-time/ttn-otaa-network-time.ino'
     PLATFORMIO_BUILD_FLAGS='-D CFG_as923   -D CFG_sx1276_radio -D LMIC_ENABLE_DeviceTimeReq=1 -D COMPILE_REGRESSION_TEST -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS' platformio ci --project-option="lib_deps=Time" --lib . --board heltec_wifi_lora_32 'examples/ttn-otaa-network-time/ttn-otaa-network-time.ino'
     PLATFORMIO_BUILD_FLAGS='-D CFG_as923jp -D CFG_sx1276_radio -D LMIC_ENABLE_DeviceTimeReq=1 -D COMPILE_REGRESSION_TEST -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS' platformio ci --project-option="lib_deps=Time" --lib . --board heltec_wifi_lora_32 'examples/ttn-otaa-network-time/ttn-otaa-network-time.ino'
     PLATFORMIO_BUILD_FLAGS='-D CFG_kr920   -D CFG_sx1276_radio -D LMIC_ENABLE_DeviceTimeReq=1 -D COMPILE_REGRESSION_TEST -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS' platformio ci --project-option="lib_deps=Time" --lib . --board heltec_wifi_lora_32 'examples/ttn-otaa-network-time/ttn-otaa-network-time.ino'
@@ -72,7 +72,7 @@ then
     # # Compile "raw-feather" example in all the regions
     # PLATFORMIO_BUILD_FLAGS='-D ARDUINO_AVR_FEATHER32U4 -D CFG_us915   -D COMPILE_REGRESSION_TEST -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS -D CFG_sx1276_radio' platformio ci --lib . --board heltec_wifi_lora_32 'examples/raw-feather/raw-feather.ino'
     # PLATFORMIO_BUILD_FLAGS='-D ARDUINO_AVR_FEATHER32U4 -D CFG_eu868   -D COMPILE_REGRESSION_TEST -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS -D CFG_sx1276_radio' platformio ci --lib . --board heltec_wifi_lora_32 'examples/raw-feather/raw-feather.ino'
-    # PLATFORMIO_BUILD_FLAGS='-D ARDUINO_AVR_FEATHER32U4 -D CFG_au921   -D COMPILE_REGRESSION_TEST -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS -D CFG_sx1276_radio' platformio ci --lib . --board heltec_wifi_lora_32 'examples/raw-feather/raw-feather.ino'
+    # PLATFORMIO_BUILD_FLAGS='-D ARDUINO_AVR_FEATHER32U4 -D CFG_au915   -D COMPILE_REGRESSION_TEST -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS -D CFG_sx1276_radio' platformio ci --lib . --board heltec_wifi_lora_32 'examples/raw-feather/raw-feather.ino'
     # PLATFORMIO_BUILD_FLAGS='-D ARDUINO_AVR_FEATHER32U4 -D CFG_as923   -D COMPILE_REGRESSION_TEST -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS -D CFG_sx1276_radio' platformio ci --lib . --board heltec_wifi_lora_32 'examples/raw-feather/raw-feather.ino'
     # PLATFORMIO_BUILD_FLAGS='-D ARDUINO_AVR_FEATHER32U4 -D CFG_as923jp -D COMPILE_REGRESSION_TEST -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS -D CFG_sx1276_radio' platformio ci --lib . --board heltec_wifi_lora_32 'examples/raw-feather/raw-feather.ino'
     # PLATFORMIO_BUILD_FLAGS='-D ARDUINO_AVR_FEATHER32U4 -D CFG_kr920   -D COMPILE_REGRESSION_TEST -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS -D CFG_sx1276_radio' platformio ci --lib . --board heltec_wifi_lora_32 'examples/raw-feather/raw-feather.ino'
@@ -80,7 +80,7 @@ then
 
     # Compile "ttn-otaa-feather-us915" example in US and AU regions
     PLATFORMIO_BUILD_FLAGS='-D ARDUINO_AVR_FEATHER32U4 -D CFG_us915 -D CFG_sx1276_radio -D COMPILE_REGRESSION_TEST -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS' platformio ci --lib . --board heltec_wifi_lora_32 'examples/ttn-otaa-feather-us915/ttn-otaa-feather-us915.ino'
-    PLATFORMIO_BUILD_FLAGS='-D ARDUINO_AVR_FEATHER32U4 -D CFG_au921 -D CFG_sx1276_radio -D COMPILE_REGRESSION_TEST -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS' platformio ci --lib . --board heltec_wifi_lora_32 'examples/ttn-otaa-feather-us915/ttn-otaa-feather-us915.ino'
+    PLATFORMIO_BUILD_FLAGS='-D ARDUINO_AVR_FEATHER32U4 -D CFG_au915 -D CFG_sx1276_radio -D COMPILE_REGRESSION_TEST -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS' platformio ci --lib . --board heltec_wifi_lora_32 'examples/ttn-otaa-feather-us915/ttn-otaa-feather-us915.ino'
 
     # Compile "ttn-otaa-feather-us915" example in US region with interrupts
     PLATFORMIO_BUILD_FLAGS='-D ARDUINO_AVR_FEATHER32U4 -D CFG_us915 -D CFG_sx1276_radio -D LMIC_USE_INTERRUPTS -D COMPILE_REGRESSION_TEST -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS' platformio ci --lib . --board heltec_wifi_lora_32 'examples/ttn-otaa-feather-us915/ttn-otaa-feather-us915.ino'
@@ -91,11 +91,11 @@ then
 
     # Compile "ttn-otaa-feather-us915-dht22" example in all relevant regions
     PLATFORMIO_BUILD_FLAGS='-D ARDUINO_AVR_FEATHER32U4 -D CFG_us915 -D CFG_sx1276_radio -D COMPILE_REGRESSION_TEST -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS' platformio ci --project-option="lib_deps=DHT sensor library, Adafruit Unified Sensor" --lib . --board heltec_wifi_lora_32 'examples/ttn-otaa-feather-us915-dht22/ttn-otaa-feather-us915-dht22.ino'
-    PLATFORMIO_BUILD_FLAGS='-D ARDUINO_AVR_FEATHER32U4 -D CFG_au921 -D CFG_sx1276_radio -D COMPILE_REGRESSION_TEST -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS' platformio ci --project-option="lib_deps=DHT sensor library, Adafruit Unified Sensor" --lib . --board heltec_wifi_lora_32 'examples/ttn-otaa-feather-us915-dht22/ttn-otaa-feather-us915-dht22.ino'
+    PLATFORMIO_BUILD_FLAGS='-D ARDUINO_AVR_FEATHER32U4 -D CFG_au915 -D CFG_sx1276_radio -D COMPILE_REGRESSION_TEST -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS' platformio ci --project-option="lib_deps=DHT sensor library, Adafruit Unified Sensor" --lib . --board heltec_wifi_lora_32 'examples/ttn-otaa-feather-us915-dht22/ttn-otaa-feather-us915-dht22.ino'
 
     # Compile "ttn-abp-feather-us915-dht22" example in all relevant regions with sx1276
     PLATFORMIO_BUILD_FLAGS='-D ARDUINO_AVR_FEATHER32U4 -D CFG_us915 -D CFG_sx1276_radio -D COMPILE_REGRESSION_TEST -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS' platformio ci --project-option="lib_deps=DHT sensor library, Adafruit Unified Sensor" --lib . --board heltec_wifi_lora_32 'examples/ttn-abp-feather-us915-dht22/ttn-abp-feather-us915-dht22.ino'
-    PLATFORMIO_BUILD_FLAGS='-D ARDUINO_AVR_FEATHER32U4 -D CFG_au921 -D CFG_sx1276_radio -D COMPILE_REGRESSION_TEST -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS' platformio ci --project-option="lib_deps=DHT sensor library, Adafruit Unified Sensor" --lib . --board heltec_wifi_lora_32 'examples/ttn-abp-feather-us915-dht22/ttn-abp-feather-us915-dht22.ino'
+    PLATFORMIO_BUILD_FLAGS='-D ARDUINO_AVR_FEATHER32U4 -D CFG_au915 -D CFG_sx1276_radio -D COMPILE_REGRESSION_TEST -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS' platformio ci --project-option="lib_deps=DHT sensor library, Adafruit Unified Sensor" --lib . --board heltec_wifi_lora_32 'examples/ttn-abp-feather-us915-dht22/ttn-abp-feather-us915-dht22.ino'
 
     # COMMENTED BECAUSE build fails with
     #   src/raw-feather.ino:119:22: error: 'class HardwareSerial' has no member named 'dtr'
@@ -123,11 +123,11 @@ then
     # TESTS FOR TARGET "avr", i.e. BOARD feather32u4
 
     PLATFORMIO_BUILD_FLAGS='-D COMPILE_REGRESSION_TEST'                                                                              platformio ci --lib . --board feather32u4 'examples/ttn-otaa-feather-us915/ttn-otaa-feather-us915.ino'
-    PLATFORMIO_BUILD_FLAGS='-D COMPILE_REGRESSION_TEST -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS -D CFG_au921   -D CFG_sx1276_radio' platformio ci --lib . --board feather32u4 'examples/ttn-otaa-feather-us915/ttn-otaa-feather-us915.ino'
+    PLATFORMIO_BUILD_FLAGS='-D COMPILE_REGRESSION_TEST -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS -D CFG_au915   -D CFG_sx1276_radio' platformio ci --lib . --board feather32u4 'examples/ttn-otaa-feather-us915/ttn-otaa-feather-us915.ino'
 
     PLATFORMIO_BUILD_FLAGS='-D COMPILE_REGRESSION_TEST -D LED_BUILTIN=13'                                                                              platformio ci --lib . --board feather32u4 'examples/raw-feather/raw-feather.ino'
     PLATFORMIO_BUILD_FLAGS='-D COMPILE_REGRESSION_TEST -D LED_BUILTIN=13 -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS -D CFG_eu868   -D CFG_sx1276_radio' platformio ci --lib . --board feather32u4 'examples/raw-feather/raw-feather.ino'
-    PLATFORMIO_BUILD_FLAGS='-D COMPILE_REGRESSION_TEST -D LED_BUILTIN=13 -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS -D CFG_au921   -D CFG_sx1276_radio' platformio ci --lib . --board feather32u4 'examples/raw-feather/raw-feather.ino'
+    PLATFORMIO_BUILD_FLAGS='-D COMPILE_REGRESSION_TEST -D LED_BUILTIN=13 -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS -D CFG_au915   -D CFG_sx1276_radio' platformio ci --lib . --board feather32u4 'examples/raw-feather/raw-feather.ino'
     PLATFORMIO_BUILD_FLAGS='-D COMPILE_REGRESSION_TEST -D LED_BUILTIN=13 -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS -D CFG_as923   -D CFG_sx1276_radio' platformio ci --lib . --board feather32u4 'examples/raw-feather/raw-feather.ino'
     PLATFORMIO_BUILD_FLAGS='-D COMPILE_REGRESSION_TEST -D LED_BUILTIN=13 -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS -D CFG_as923jp -D CFG_sx1276_radio' platformio ci --lib . --board feather32u4 'examples/raw-feather/raw-feather.ino'
     PLATFORMIO_BUILD_FLAGS='-D COMPILE_REGRESSION_TEST -D LED_BUILTIN=13 -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS -D CFG_kr920   -D CFG_sx1276_radio' platformio ci --lib . --board feather32u4 'examples/raw-feather/raw-feather.ino'

--- a/ci/platformio.sh
+++ b/ci/platformio.sh
@@ -139,6 +139,9 @@ then
 
     # Make sure debug prints work
     PLATFORMIO_BUILD_FLAGS='-D COMPILE_REGRESSION_TEST -D LED_BUILTIN=13 -D LMIC_DEBUG_LEVEL=2 -D LMIC_PRINTF_TO=Serial' platformio ci --lib . --board feather32u4 'examples/raw/raw.ino'
+
+    # Check build with deprecated CFG_au921 flag
+    PLATFORMIO_BUILD_FLAGS='-D COMPILE_REGRESSION_TEST -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS -D CFG_au921   -D CFG_sx1276_radio' platformio ci --lib . --board feather32u4 'examples/ttn-otaa-feather-us915/ttn-otaa-feather-us915.ino'
 elif [ "$TARGET" == "samd" ]
 then
     echo "WARNING: target '$TARGET' is not configured yet."

--- a/examples/raw-feather/raw-feather.ino
+++ b/examples/raw-feather/raw-feather.ino
@@ -309,7 +309,7 @@ void setup() {
 
   // default tx power for US: 21 dBm
   LMIC.txpow = 21;
-#elif defined(CFG_au921)
+#elif defined(CFG_au915)
   // make it easier for test, by pull the parameters up to the top of the
   // block. Ideally, we'd use the serial port to drive this; or have
   // a voting protocol where one side is elected the controller and
@@ -340,30 +340,30 @@ void setup() {
         {
         if (kUplinkChannel < 64)
                 {
-                LMIC.freq = AU921_125kHz_UPFBASE +
-                            kUplinkChannel * AU921_125kHz_UPFSTEP;
+                LMIC.freq = AU915_125kHz_UPFBASE +
+                            kUplinkChannel * AU915_125kHz_UPFSTEP;
                 uBandwidth = 125;
                 }
         else
                 {
-                LMIC.freq = AU921_500kHz_UPFBASE +
-                            (kUplinkChannel - 64) * AU921_500kHz_UPFSTEP;
+                LMIC.freq = AU915_500kHz_UPFBASE +
+                            (kUplinkChannel - 64) * AU915_500kHz_UPFSTEP;
                 uBandwidth = 500;
                 }
         }
   else
         {
         // downlink channel
-        LMIC.freq = AU921_500kHz_DNFBASE +
-                    kDownlinkChannel * AU921_500kHz_DNFSTEP;
+        LMIC.freq = AU915_500kHz_DNFBASE +
+                    kDownlinkChannel * AU915_500kHz_DNFSTEP;
         uBandwidth = 500;
         }
 
   // Use a suitable spreading factor
   if (uBandwidth < 500)
-        LMIC.datarate = AU921_DR_SF7;         // DR4
+        LMIC.datarate = AU915_DR_SF7;         // DR4
   else
-        LMIC.datarate = AU921_DR_SF12CR;      // DR8
+        LMIC.datarate = AU915_DR_SF12CR;      // DR8
 
   // default tx power for AU: 30 dBm
   LMIC.txpow = 30;

--- a/examples/raw-halconfig/raw-halconfig.ino
+++ b/examples/raw-halconfig/raw-halconfig.ino
@@ -275,7 +275,7 @@ void setup() {
 
   // default tx power for US: 21 dBm
   LMIC.txpow = 21;
-#elif defined(CFG_au921)
+#elif defined(CFG_au915)
   // make it easier for test, by pull the parameters up to the top of the
   // block. Ideally, we'd use the serial port to drive this; or have
   // a voting protocol where one side is elected the controller and
@@ -306,30 +306,30 @@ void setup() {
         {
         if (kUplinkChannel < 64)
                 {
-                LMIC.freq = AU921_125kHz_UPFBASE +
-                            kUplinkChannel * AU921_125kHz_UPFSTEP;
+                LMIC.freq = AU915_125kHz_UPFBASE +
+                            kUplinkChannel * AU915_125kHz_UPFSTEP;
                 uBandwidth = 125;
                 }
         else
                 {
-                LMIC.freq = AU921_500kHz_UPFBASE +
-                            (kUplinkChannel - 64) * AU921_500kHz_UPFSTEP;
+                LMIC.freq = AU915_500kHz_UPFBASE +
+                            (kUplinkChannel - 64) * AU915_500kHz_UPFSTEP;
                 uBandwidth = 500;
                 }
         }
   else
         {
         // downlink channel
-        LMIC.freq = AU921_500kHz_DNFBASE +
-                    kDownlinkChannel * AU921_500kHz_DNFSTEP;
+        LMIC.freq = AU915_500kHz_DNFBASE +
+                    kDownlinkChannel * AU915_500kHz_DNFSTEP;
         uBandwidth = 500;
         }
 
   // Use a suitable spreading factor
   if (uBandwidth < 500)
-        LMIC.datarate = AU921_DR_SF7;         // DR4
+        LMIC.datarate = AU915_DR_SF7;         // DR4
   else
-        LMIC.datarate = AU921_DR_SF12CR;      // DR8
+        LMIC.datarate = AU915_DR_SF12CR;      // DR8
 
   // default tx power for AU: 30 dBm
   LMIC.txpow = 30;

--- a/project_config/lmic_project_config.h
+++ b/project_config/lmic_project_config.h
@@ -1,7 +1,7 @@
 // project-specific definitions
 //#define CFG_eu868 1
 #define CFG_us915 1
-//#define CFG_au921 1
+//#define CFG_au915 1
 //#define CFG_as923 1
 // #define LMIC_COUNTRY_CODE LMIC_COUNTRY_CODE_JP	/* for as923-JP */
 //#define CFG_kr920 1

--- a/src/lmic/lmic_bandplan.h
+++ b/src/lmic/lmic_bandplan.h
@@ -37,8 +37,8 @@
 # include "lmic_bandplan_eu868.h"
 #elif defined(CFG_us915)
 # include "lmic_bandplan_us915.h"
-#elif defined(CFG_au921)
-# include "lmic_bandplan_au921.h"
+#elif defined(CFG_au915)
+# include "lmic_bandplan_au915.h"
 #elif defined(CFG_as923)
 # include "lmic_bandplan_as923.h"
 #elif defined(CFG_kr920)

--- a/src/lmic/lmic_bandplan_au915.h
+++ b/src/lmic/lmic_bandplan_au915.h
@@ -26,8 +26,8 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#ifndef _lmic_bandplan_au921_h_
-# define _lmic_bandplan_au921_h_
+#ifndef _lmic_bandplan_au915_h_
+# define _lmic_bandplan_au915_h_
 
 // preconditions for lmic_us_like.h
 #define LMICuslike_getFirst500kHzDR()   (LORAWAN_DR6)
@@ -37,33 +37,33 @@
 # include "lmic_us_like.h"
 #endif
 
-// return maximum frame length (including PHY header) for this data rate (au921); 0 --> not valid dr.
-uint8_t LMICau921_maxFrameLen(uint8_t dr);
+// return maximum frame length (including PHY header) for this data rate (au915); 0 --> not valid dr.
+uint8_t LMICau915_maxFrameLen(uint8_t dr);
 // return maximum frame length (including PHY header) for this data rate; 0 --> not valid dr.
-#define LMICbandplan_maxFrameLen(dr) LMICau921_maxFrameLen(dr)
+#define LMICbandplan_maxFrameLen(dr) LMICau915_maxFrameLen(dr)
 
-int8_t LMICau921_pow2dbm(uint8_t mcmd_ladr_p1);
-#define pow2dBm(mcmd_ladr_p1) LMICau921_pow2dbm(mcmd_ladr_p1)
+int8_t LMICau915_pow2dbm(uint8_t mcmd_ladr_p1);
+#define pow2dBm(mcmd_ladr_p1) LMICau915_pow2dbm(mcmd_ladr_p1)
 
-ostime_t LMICau921_dr2hsym(uint8_t dr);
-#define dr2hsym(dr) LMICau921_dr2hsym(dr)
+ostime_t LMICau915_dr2hsym(uint8_t dr);
+#define dr2hsym(dr) LMICau915_dr2hsym(dr)
 
 
 #define LMICbandplan_getInitialDrJoin() (LORAWAN_DR2)
 
-void LMICau921_initJoinLoop(void);
-#define LMICbandplan_initJoinLoop()     LMICau921_initJoinLoop()
+void LMICau915_initJoinLoop(void);
+#define LMICbandplan_initJoinLoop()     LMICau915_initJoinLoop()
 
-void LMICau921_setBcnRxParams(void);
-#define LMICbandplan_setBcnRxParams() LMICau921_setBcnRxParams()
+void LMICau915_setBcnRxParams(void);
+#define LMICbandplan_setBcnRxParams() LMICau915_setBcnRxParams()
 
-u4_t LMICau921_convFreq(xref2cu1_t ptr);
-#define LMICbandplan_convFreq(ptr)      LMICau921_convFreq(ptr)
+u4_t LMICau915_convFreq(xref2cu1_t ptr);
+#define LMICbandplan_convFreq(ptr)      LMICau915_convFreq(ptr)
 
-void LMICau921_setRx1Params(void);
-#define LMICbandplan_setRx1Params()     LMICau921_setRx1Params()
+void LMICau915_setRx1Params(void);
+#define LMICbandplan_setRx1Params()     LMICau915_setRx1Params()
 
-void LMICau921_updateTx(ostime_t txbeg);
-#define LMICbandplan_updateTx(txbeg)    LMICau921_updateTx(txbeg)
+void LMICau915_updateTx(ostime_t txbeg);
+#define LMICbandplan_updateTx(txbeg)    LMICau915_updateTx(txbeg)
 
-#endif // _lmic_bandplan_au921_h_
+#endif // _lmic_bandplan_au915_h_

--- a/src/lmic/lmic_config_preconditions.h
+++ b/src/lmic/lmic_config_preconditions.h
@@ -92,7 +92,7 @@ Revision history:
 # include CFG_TEXT_1(ARDUINO_LMIC_PROJECT_CONFIG_H)
 #endif /* ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS */
 
-#ifdef CFG_au921
+#if defined(CFG_au921) && !defined(CFG_au915)
 #   warning "CFG_au921 was deprecated in favour of CFG_au915. Support for CFG_au921 might be removed in the future."
 #   define CFG_au915
 #endif

--- a/src/lmic/lmic_config_preconditions.h
+++ b/src/lmic/lmic_config_preconditions.h
@@ -66,7 +66,7 @@ Revision history:
 #define LMIC_REGION_us915    2
 #define LMIC_REGION_cn783    3
 #define LMIC_REGION_eu433    4
-#define LMIC_REGION_au921    5
+#define LMIC_REGION_au915    5
 #define LMIC_REGION_cn490    6
 #define LMIC_REGION_as923    7
 #define LMIC_REGION_kr920    8
@@ -100,7 +100,7 @@ Revision history:
                                 (1 << LMIC_REGION_us915) |      \
                              /* (1 << LMIC_REGION_cn783) | */   \
                              /* (1 << LMIC_REGION_eu433) | */   \
-                                (1 << LMIC_REGION_au921) |      \
+                                (1 << LMIC_REGION_au915) |      \
                              /* (1 << LMIC_REGION_cn490) | */   \
                                 (1 << LMIC_REGION_as923) |      \
                                 (1 << LMIC_REGION_kr920) |      \
@@ -124,7 +124,7 @@ Revision history:
                          (defined(CFG_us915) << LMIC_REGION_us915) | \
                          (defined(CFG_cn783) << LMIC_REGION_cn783) | \
                          (defined(CFG_eu433) << LMIC_REGION_eu433) | \
-                         (defined(CFG_au921) << LMIC_REGION_au921) | \
+                         (defined(CFG_au915) << LMIC_REGION_au915) | \
                          (defined(CFG_cn490) << LMIC_REGION_cn490) | \
                          (defined(CFG_as923) << LMIC_REGION_as923) | \
                          (defined(CFG_kr920) << LMIC_REGION_kr920) | \
@@ -142,8 +142,8 @@ Revision history:
 # define CFG_region     LMIC_REGION_cn783
 #elif defined(CFG_eu433)
 # define CFG_region     LMIC_REGION_eu433
-#elif defined(CFG_au921)
-# define CFG_region     LMIC_REGION_au921
+#elif defined(CFG_au915)
+# define CFG_region     LMIC_REGION_au915
 #elif defined(CFG_cn490)
 # define CFG_region     LMIC_REGION_cn490
 #elif defined(CFG_as923jp)
@@ -170,7 +170,7 @@ Revision history:
                              /* (1 << LMIC_REGION_us915) | */   \
                                 (1 << LMIC_REGION_cn783) |      \
                                 (1 << LMIC_REGION_eu433) |      \
-                             /* (1 << LMIC_REGION_au921) | */   \
+                             /* (1 << LMIC_REGION_au915) | */   \
                              /* (1 << LMIC_REGION_cn490) | */   \
                                 (1 << LMIC_REGION_as923) |      \
                                 (1 << LMIC_REGION_kr920) |      \
@@ -188,7 +188,7 @@ Revision history:
                                 (1 << LMIC_REGION_us915) |      \
                              /* (1 << LMIC_REGION_cn783) | */   \
                              /* (1 << LMIC_REGION_eu433) | */   \
-                                (1 << LMIC_REGION_au921) |      \
+                                (1 << LMIC_REGION_au915) |      \
                              /* (1 << LMIC_REGION_cn490) | */   \
                              /* (1 << LMIC_REGION_as923) | */   \
                              /* (1 << LMIC_REGION_kr920) | */   \

--- a/src/lmic/lmic_config_preconditions.h
+++ b/src/lmic/lmic_config_preconditions.h
@@ -92,6 +92,11 @@ Revision history:
 # include CFG_TEXT_1(ARDUINO_LMIC_PROJECT_CONFIG_H)
 #endif /* ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS */
 
+#ifdef CFG_au921
+#   warning "CFG_au921 was deprecated in favour of CFG_au915. Support for CFG_au921 might be removed in the future."
+#   define CFG_au915
+#endif
+
 // a mask of the supported regions
 // TODO(tmm@mcci.com) consider moving this block to a central file as it's not
 // user-editable.

--- a/src/lmic/lmic_config_preconditions.h
+++ b/src/lmic/lmic_config_preconditions.h
@@ -97,6 +97,11 @@ Revision history:
 #   define CFG_au915
 #endif
 
+// for backwards compatibility to legacy code, define CFG_au921 if we see CFG_au915.
+#if defined(CFG_au915) && !defined(CFG_au921)
+#   define CFG_au921
+#endif
+
 // a mask of the supported regions
 // TODO(tmm@mcci.com) consider moving this block to a central file as it's not
 // user-editable.

--- a/src/lmic/lorabase.h
+++ b/src/lmic/lorabase.h
@@ -226,28 +226,28 @@ enum _dr_configured_t {
 };
 # endif // LMIC_DR_LEGACY
 
-#elif defined(CFG_au921)  // =========================================
+#elif defined(CFG_au915)  // =========================================
 
-#include "lorabase_au921.h"
+#include "lorabase_au915.h"
 
 // per 2.5.3: must be implemented
 #define LMIC_ENABLE_TxParamSetupReq	1
 
-enum { DR_DFLTMIN       = AU921_DR_SF7 };  // DR5
+enum { DR_DFLTMIN       = AU915_DR_SF7 };  // DR5
 
                                 // DR_PAGE is a debugging parameter; it must be defined but it has no use in arduino-lmic
-enum { DR_PAGE          = DR_PAGE_AU921 };
+enum { DR_PAGE          = DR_PAGE_AU915 };
 
 //enum { CHNL_PING        = 0 }; // used only for default init of state (follows beacon - rotating)
-enum { FREQ_PING        = AU921_500kHz_DNFBASE + 0*AU921_500kHz_DNFSTEP };  // default ping freq
-enum { DR_PING          = AU921_DR_SF10CR };       // default ping DR
+enum { FREQ_PING        = AU915_500kHz_DNFBASE + 0*AU915_500kHz_DNFSTEP };  // default ping freq
+enum { DR_PING          = AU915_DR_SF10CR };       // default ping DR
 //enum { CHNL_DNW2        = 0 };
-enum { FREQ_DNW2        = AU921_500kHz_DNFBASE + 0*AU921_500kHz_DNFSTEP };
-enum { DR_DNW2          = AU921_DR_SF12CR };                  // DR8
+enum { FREQ_DNW2        = AU915_500kHz_DNFBASE + 0*AU915_500kHz_DNFSTEP };
+enum { DR_DNW2          = AU915_DR_SF12CR };                  // DR8
 enum { CHNL_BCN         = 0 }; // used only for default init of state (rotating beacon scheme)
-enum { DR_BCN           = AU921_DR_SF10CR };
+enum { DR_BCN           = AU915_DR_SF10CR };
 enum { AIRTIME_BCN      = 72192 };  // micros ... TODO(tmm@mcci.com) check.
-enum { LMIC_REGION_EIRP = AU921_LMIC_REGION_EIRP };         // region uses EIRP
+enum { LMIC_REGION_EIRP = AU915_LMIC_REGION_EIRP };         // region uses EIRP
 
 enum {
         // Beacon frame format AU DR10/SF10 500kHz
@@ -264,20 +264,20 @@ enum {
 
 # if LMIC_DR_LEGACY
 enum _dr_configured_t {
-        DR_SF12    = AU921_DR_SF12,
-        DR_SF11    = AU921_DR_SF11,
-        DR_SF10    = AU921_DR_SF10,
-        DR_SF9     = AU921_DR_SF9,
-        DR_SF8     = AU921_DR_SF8,
-        DR_SF7     = AU921_DR_SF7,
-        DR_SF8C    = AU921_DR_SF8C,
-        DR_NONE    = AU921_DR_NONE,
-        DR_SF12CR  = AU921_DR_SF12CR,
-        DR_SF11CR  = AU921_DR_SF11CR,
-        DR_SF10CR  = AU921_DR_SF10CR,
-        DR_SF9CR   = AU921_DR_SF9CR,
-        DR_SF8CR   = AU921_DR_SF8CR,
-        DR_SF7CR   = AU921_DR_SF7CR
+        DR_SF12    = AU915_DR_SF12,
+        DR_SF11    = AU915_DR_SF11,
+        DR_SF10    = AU915_DR_SF10,
+        DR_SF9     = AU915_DR_SF9,
+        DR_SF8     = AU915_DR_SF8,
+        DR_SF7     = AU915_DR_SF7,
+        DR_SF8C    = AU915_DR_SF8C,
+        DR_NONE    = AU915_DR_NONE,
+        DR_SF12CR  = AU915_DR_SF12CR,
+        DR_SF11CR  = AU915_DR_SF11CR,
+        DR_SF10CR  = AU915_DR_SF10CR,
+        DR_SF9CR   = AU915_DR_SF9CR,
+        DR_SF8CR   = AU915_DR_SF8CR,
+        DR_SF7CR   = AU915_DR_SF7CR
 };
 # endif // LMIC_DR_LEGACY
 

--- a/src/lmic/lorabase_au915.h
+++ b/src/lmic/lorabase_au915.h
@@ -28,8 +28,8 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#ifndef _lorabase_au921_h_
-#define _lorabase_au921_h_
+#ifndef _lorabase_au915_h_
+#define _lorabase_au915_h_
 
 #ifndef _LMIC_CONFIG_PRECONDITIONS_H_
 # include "lmic_config_preconditions.h"
@@ -37,53 +37,53 @@
 
 /****************************************************************************\
 |
-| Basic definitions for AS921 (always in scope)
+| Basic definitions for AU 915 (always in scope)
 |
 \****************************************************************************/
 
-// Frequency plan for AU 921 MHz
-enum _dr_as921_t {
-        AU921_DR_SF12 = 0,
-        AU921_DR_SF11,
-        AU921_DR_SF10,
-        AU921_DR_SF9,
-        AU921_DR_SF8,
-        AU921_DR_SF7,
-        AU921_DR_SF8C,
-        AU921_DR_NONE,
+// Frequency plan for AU 915 MHz
+enum _dr_au915_t {
+        AU915_DR_SF12 = 0,
+        AU915_DR_SF11,
+        AU915_DR_SF10,
+        AU915_DR_SF9,
+        AU915_DR_SF8,
+        AU915_DR_SF7,
+        AU915_DR_SF8C,
+        AU915_DR_NONE,
         // Devices behind a router:
-        AU921_DR_SF12CR = 8,
-        AU921_DR_SF11CR,
-        AU921_DR_SF10CR,
-        AU921_DR_SF9CR,
-        AU921_DR_SF8CR,
-        AU921_DR_SF7CR
+        AU915_DR_SF12CR = 8,
+        AU915_DR_SF11CR,
+        AU915_DR_SF10CR,
+        AU915_DR_SF9CR,
+        AU915_DR_SF8CR,
+        AU915_DR_SF7CR
 };
 
-// Default frequency plan for AU 921MHz
+// Default frequency plan for AU 915MHz
 enum {
-        AU921_125kHz_UPFBASE = 915200000,
-        AU921_125kHz_UPFSTEP = 200000,
-        AU921_500kHz_UPFBASE = 915900000,
-        AU921_500kHz_UPFSTEP = 1600000,
-        AU921_500kHz_DNFBASE = 923300000,
-        AU921_500kHz_DNFSTEP = 600000
+        AU915_125kHz_UPFBASE = 915200000,
+        AU915_125kHz_UPFSTEP = 200000,
+        AU915_500kHz_UPFBASE = 915900000,
+        AU915_500kHz_UPFSTEP = 1600000,
+        AU915_500kHz_DNFBASE = 923300000,
+        AU915_500kHz_DNFSTEP = 600000
 };
 enum {
-        AU921_FREQ_MIN = 915000000,
-        AU921_FREQ_MAX = 928000000
+        AU915_FREQ_MIN = 915000000,
+        AU915_FREQ_MAX = 928000000
 };
 enum {
-        AU921_TX_EIRP_MAX_DBM = 30      // 30 dBm
+        AU915_TX_EIRP_MAX_DBM = 30      // 30 dBm
 };
 enum {
         // initial value of UplinkDwellTime before TxParamSetupReq received.
-        AU921_INITIAL_TxParam_UplinkDwellTime = 1,
-        AU921_UPLINK_DWELL_TIME_osticks = sec2osticks(20),
+        AU915_INITIAL_TxParam_UplinkDwellTime = 1,
+        AU915_UPLINK_DWELL_TIME_osticks = sec2osticks(20),
 };
 
-enum { DR_PAGE_AU921 = 0x10 * (LMIC_REGION_au921 - 1) };
+enum { DR_PAGE_AU915 = 0x10 * (LMIC_REGION_au915 - 1) };
 
-enum { AU921_LMIC_REGION_EIRP = 1 };         // region uses EIRP
+enum { AU915_LMIC_REGION_EIRP = 1 };         // region uses EIRP
 
-#endif /* _lorabase_au921_h_ */
+#endif /* _lorabase_au915_h_ */


### PR DESCRIPTION
Closes #363 

Currently it fails in CI because, for the MCCI Catena's BSP, the `lorawan_region` parameter is named au921, not au915.

The error is the following:
```
$ _notstm32l0 ||  arduino --verify --board $(_stm32l0opts '' au915  ) $MCCI_STM32_OPTS $PWD/examples/raw-feather/raw-feather.ino

Picked up JAVA_TOOL_OPTIONS: 
Loading configuration...
Initializing packages...
Preparing boards...
Error: au915: Invalid value for option "lorawan_region" for board "mcci_catena_4551"
The command "_notstm32l0 ||  arduino --verify --board $(_stm32l0opts '' au915  ) $MCCI_STM32_OPTS $PWD/examples/raw-feather/raw-feather.ino" exited with 3.
```

It should be fixed if mcci-catena/ArduinoCore-samd#37 is merged.