### PR TITLE
Fix comparison for max data frame length

### DIFF
--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -1872,7 +1872,7 @@ static bit_t buildDataFrame (void) {
         LMIC.adrChanged = 0;
     }
 
-    u1_t flen = end + (txdata ? 5+dlen : 4);
+    int flen = end + (txdata ? 5+dlen : 4);
     if( flen > MAX_LEN_FRAME ) {
         // Options and payload too big - delay payload
         txdata = 0;

--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -1872,7 +1872,7 @@ static bit_t buildDataFrame (void) {
         LMIC.adrChanged = 0;
     }
 
-    int flen = end + (txdata ? 5+dlen : 4);
+    unsigned int flen = end + (txdata ? 5+dlen : 4);
     if( flen > MAX_LEN_FRAME ) {
         // Options and payload too big - delay payload
         txdata = 0;


### PR DESCRIPTION
Minor fix for ineffective comparison.

Compiler warning:
```
src/lmic/lmic.c: In function 'buildDataFrame':
src/lmic/lmic.c:1876:14: warning: comparison is always false due to limited range of data type [-Wtype-limits]
     if( flen > MAX_LEN_FRAME ) {
              ^
```