### PR TITLE
Fix line break for debug output

### DIFF
--- a/src/hal/hal.cpp
+++ b/src/hal/hal.cpp
@@ -322,6 +322,8 @@ void hal_printf_init() {
 #else // defined(__AVR)
 static int uart_putchar (char c, FILE *)
 {
+    if (c == '\n')
+        LMIC_PRINTF_TO.write('\r') ;
     LMIC_PRINTF_TO.write(c) ;
     return 0 ;
 }


### PR DESCRIPTION
If you use screen to listen for the serial output, you see something like this:

```
message
       message
```

This is because only a Line Feed and no Carriage Return is send. `\r\n` is also the default for the Arduino print class ([Print.cpp](https://github.com/esp8266/Arduino/blob/master/cores/esp8266/Print.cpp#L177)) and it's also documented in [avr-libc stdio](https://www.nongnu.org/avr-libc/user-manual/group__avr__stdio.html).