### PR TITLE
Further hack for timing while interrupts are disabled

### DIFF
--- a/src/hal/hal.cpp
+++ b/src/hal/hal.cpp
@@ -248,6 +248,15 @@ static s4_t delta_time(u4_t time) {
     return (s4_t)(time - hal_ticks());
 }
 
+// deal with boards that are stressed by no-interrupt delays #529, etc.
+#if defined(ARDUINO_DISCO_L072CZ_LRWAN1)
+# define HAL_WAITUNTIL_DOWNCONNT_MS 16      // on this board, 16 ms works better
+# define HAL_WAITUNTIL_DOWNCOUNT_THRESH ms2osticks(16)  // as does this threashold.
+#else
+# define HAL_WAITUNTIL_DWONCOUNT_MS 8       // on most boards, delay for 8 ms
+# define HAL_WAITUNTIL_DOWNCOUNT_THRESH ms2osticks(9) // but try to leave a little slack for final timing.
+#endif
+
 u4_t hal_waitUntil (u4_t time) {
     s4_t delta = delta_time(time);
     // check for already too late.
@@ -258,12 +267,12 @@ u4_t hal_waitUntil (u4_t time) {
     // will produce an accurate delay is 16383. Also, STM32 does a better
     // job with delay is less than 10,000 us; so reduce in steps.
     // It's nice to use delay() for the longer times.
-    while (delta > (9000 / US_PER_OSTICK)) {
+    while (delta > HAL_WAITUNTIL_DOWNCOUNT_THRESH) {
         // deliberately delay 8ms rather than 9ms, so we
         // will exit loop with delta typically positive.
         // Depends on BSP keeping time accurately even if interrupts
         // are disabled.
-        delay(8);
+        delay(HAL_WAITUNTIL_DWONCOUNT_MS);
         // re-synchronize.
         delta = delta_time(time);
     }


### PR DESCRIPTION
Fix #529: @kent-williams and I found that `delay(16)` works with interrupts disabled on the STM Discovery 072 board they use, but that `delay(8)` hangs. So... parameterize for now. Some day we'll remove the interrupt munging from the radio driver.