### PR TITLE
v3.1.0 - sx1272 - line misspelled

### DIFF
--- a/src/lmic/radio.c
+++ b/src/lmic/radio.c
@@ -534,7 +534,7 @@ static void configLoraModem () {
 
         // set ModemConfig2 (sf, AgcAutoOn=1 SymbTimeoutHi)
         u1_t mc2;
-        mc2 = (SX1272_MC2_SF7 + ((sf-1)<<4)) | 0x04 | ((LMIC.rxsyms >> 8) & 0x3));
+        mc2 = ((SX1272_MC2_SF7 + ((sf-1)<<4)) | 0x04 | ((LMIC.rxsyms >> 8) & 0x3));
 
 #if CFG_TxContinuousMode
         // Only for testing

--- a/src/lmic/radio.c
+++ b/src/lmic/radio.c
@@ -534,7 +534,7 @@ static void configLoraModem () {
 
         // set ModemConfig2 (sf, AgcAutoOn=1 SymbTimeoutHi)
         u1_t mc2;
-        mc2 = ((SX1272_MC2_SF7 + ((sf-1)<<4)) | 0x04 | ((LMIC.rxsyms >> 8) & 0x3));
+        mc2 = (SX1272_MC2_SF7 + ((sf-1)<<4)) | 0x04 | ((LMIC.rxsyms >> 8) & 0x3);
 
 #if CFG_TxContinuousMode
         // Only for testing


### PR DESCRIPTION
I found this misspelled on the code when I tried to use sx1272 lora module.

https://github.com/mcci-catena/arduino-lmic/blob/f67121c931c591b88602b024b289f6d4ec7159b7/src/lmic/radio.c#L537
