### PR TITLE
Use patched version of PlatformIO to avoid GitHub issue #539

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
   - sudo apt-get update -qq && sudo apt-get -y install python-pip
   - python2 --version
   - pip2 --version
-  - pip2 install --user --upgrade platformio
+  - pip2 install --user --upgrade git+git://github.com/platformio/platformio-core.git@36a222822019b243ec254ab19b8b4e83462b90d3
   - platformio update
   - platformio --version
   #


### PR DESCRIPTION
This forces CI builds to use a specific commit of the PlatformIO repo.

It is a temporary measure to fix issue #539, and should be reverted as soon as PlatformIO v 4.2.1 is released. It could also be just a matter of a few days..