### PR TITLE
Revert pinning PlatformIO version in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
   - sudo apt-get update -qq && sudo apt-get -y install python-pip
   - python2 --version
   - pip2 --version
-  - pip2 install --user --upgrade git+git://github.com/platformio/platformio-core.git@36a222822019b243ec254ab19b8b4e83462b90d3
+  - pip2 install --user --upgrade platformio
   - platformio update
   - platformio --version
   #


### PR DESCRIPTION
This reverts commit ef837b9a45fcdf0087431ebb137178a21e3c540f.

The change was introduced because of a bug in the latest version of PlatformIO.
The latest version has now been patched.