### PR TITLE
Support battery level in MAC DevStatusAns

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,15 @@ Disable or enable support for device network-time requests (LoRaWAN MAC request 
 
 If disabled, stub routines are provided that will return failure (so you don't need conditional compiles in client code).
 
+### Battery level
+
+To support battery level in MAC DevStatusAns.
+
+For battery powered devices, call `LMIC_setBattLevel()` when the battery level is measured. This ensures the last known battery level is returned in MAC DevStatusAns.
+
+For externally powered devices:
+`#define LMIC_MCMD_DEVS_BATT_DEFAULT MCMD_DEVS_EXT_POWER`
+
 ### Rarely changed variables
 
 The remaining variables are rarely used, but we list them here for completeness.

--- a/src/lmic/config.h
+++ b/src/lmic/config.h
@@ -128,6 +128,9 @@
 // DEPRECATED(tmm@mcci.com); replaced by LMIC.noRXIQinversion (dynamic). Don't define this.
 //#define DISABLE_INVERT_IQ_ON_RX
 
+// Define this in lmic_project_config.h for devices with external power.
+//#define LMIC_MCMD_DEVS_BATT_DEFAULT MCMD_DEVS_EXT_POWER
+
 // This allows choosing between multiple included AES implementations.
 // Make sure exactly one of these is uncommented.
 //

--- a/src/lmic/lmic.h
+++ b/src/lmic/lmic.h
@@ -636,6 +636,7 @@ struct lmic_t {
     u1_t        dataBeg;    // 0 or start of data (dataBeg-1 is port)
     u1_t        dataLen;    // 0 no data or zero length data, >0 byte count of data
     u1_t        frame[MAX_LEN_FRAME];
+    u1_t        batteryLevel; // Returned in MAC Command DevStatusAns
 
 #if !defined(DISABLE_BEACONS)
     u1_t        bcnChnl;
@@ -694,6 +695,7 @@ void  LMIC_setPingable   (u1_t intvExp);
 void LMIC_setSession (u4_t netid, devaddr_t devaddr, xref2u1_t nwkKey, xref2u1_t artKey);
 void LMIC_setLinkCheckMode (bit_t enabled);
 void LMIC_setClockError(u2_t error);
+void LMIC_setBattLevel(u1_t battLevel);
 
 u4_t LMIC_getSeqnoUp    (void);
 u4_t LMIC_setSeqnoUp    (u4_t);

--- a/src/lmic/oslmic.h
+++ b/src/lmic/oslmic.h
@@ -209,9 +209,6 @@ uint os_getTimeSecs (void);
 #ifndef os_radio
 void os_radio (u1_t mode);
 #endif
-#ifndef os_getBattLevel
-u1_t os_getBattLevel (void);
-#endif
 #ifndef os_queryTimeCriticalJobs
 //! Return non-zero if any jobs are scheduled between now and now+time.
 bit_t os_queryTimeCriticalJobs(ostime_t time);


### PR DESCRIPTION
I needed support for the battery level and implemented option 2 as discussed in https://github.com/mcci-catena/arduino-lmic/issues/501 , also added a define so devices on external power can just set that special value without a need to call a function. Tested it on 2 different devices, one on external power and one on batteries.