### PR TITLE
A little bit more flexible support for battery level indication

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,16 @@ Disable or enable support for device network-time requests (LoRaWAN MAC request 
 
 If disabled, stub routines are provided that will return failure (so you don't need conditional compiles in client code).
 
+### Battery level report
+
+To support battery level indication in the MAC `DevStatusAns` messages you can either use an `int LMIC_registerBattLevelCb(lmic_battlevel_cb_t *pBattLevelCb, void *pUserData)` call to register a callback function of the form `typedef u1_t lmic_battlevel_cb_t(void *pUserData);`, if you have `LMIC_ENABLE_user_events` enabled, or call `LMIC_setBattLevel(u1_t battLevel)` periodically.
+
+By default, the value supplied in the `DevStatusAns` messages will be `MCMD_DEVS_BATT_NOINFO`, but you can change this behaviour for the externally powered devices by adding to your project config file the following line:
+
+```
+#define LMIC_MCMD_DEVS_BATT_DEFAULT MCMD_DEVS_EXT_POWER
+```
+
 ### Rarely changed variables
 
 The remaining variables are rarely used, but we list them here for completeness.

--- a/src/lmic/config.h
+++ b/src/lmic/config.h
@@ -128,6 +128,11 @@
 // DEPRECATED(tmm@mcci.com); replaced by LMIC.noRXIQinversion (dynamic). Don't define this.
 //#define DISABLE_INVERT_IQ_ON_RX
 
+// Use MCMD_DEVS_EXT_POWER value here for externally powered devices
+#if !defined(LMIC_MCMD_DEVS_BATT_DEFAULT)
+# define LMIC_MCMD_DEVS_BATT_DEFAULT MCMD_DEVS_BATT_NOINFO
+#endif
+
 // This allows choosing between multiple included AES implementations.
 // Make sure exactly one of these is uncommented.
 //

--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -123,7 +123,7 @@ u1_t os_getBattLevel (void) {
     if (LMIC.client.battLevelCb != NULL)
         return LMIC.client.battLevelCb(LMIC.client.battLevelUserData);
  #endif
-    return MCMD_DEVS_BATT_NOINFO;
+    return LMIC.batteryLevel;
 }
 #endif
 

--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -943,7 +943,7 @@ scan_mac_cmds(
             // LMIC.snr is SNR times 4, convert to real SNR; rounding towards zero.
             const int snr = (LMIC.snr + 2) / 4;
             // per [1.02] 5.5. the margin is the SNR.
-            LMIC.devAnsMargin = (u1_t)(0b00111111 & (snr <= -32 ? -32 : snr >= 31 ? 31 : snr));
+            LMIC.devAnsMargin = (u1_t)(0x3F & (snr <= -32 ? -32 : snr >= 31 ? 31 : snr));
 
             response_fit = put_mac_uplink_byte3(MCMD_DevStatusAns, os_getBattLevel(), LMIC.devAnsMargin);
             break;

--- a/src/lmic/lmic.h
+++ b/src/lmic/lmic.h
@@ -353,6 +353,7 @@ enum {
 typedef void LMIC_ABI_STD lmic_rxmessage_cb_t(void *pUserData, uint8_t port, const uint8_t *pMessage, size_t nMessage);
 typedef void LMIC_ABI_STD lmic_txmessage_cb_t(void *pUserData, int fSuccess);
 typedef void LMIC_ABI_STD lmic_event_cb_t(void *pUserData, ev_t e);
+typedef u1_t LMIC_ABI_STD lmic_battlevel_cb_t(void *pUserData);
 
 // network time request callback function
 // defined unconditionally, because APIs and types can't change based on config.
@@ -425,6 +426,8 @@ struct lmic_client_data_s {
     void                *rxMessageUserData; //! data for rxMessageCb
     lmic_txmessage_cb_t *txMessageCb;       //! transmit-complete message handler; reset on each tx complete.
     void                *txMessageUserData; //! data for txMessageCb.
+    lmic_battlevel_cb_t *battLevelCb;       //! user-supplied callback function to get battery level for Dev
+    void                *battLevelUserData; //! data for battLevelCb.
 #endif // LMIC_ENABLE_user_events
 
     /* next we have things that are (u)int32_t */
@@ -600,6 +603,7 @@ struct lmic_t {
 
     u1_t        margin;
     s1_t        devAnsMargin; // SNR value between -32 and 31 (inclusive) for the last successfully received DevStatusReq command
+    u1_t        batteryLevel; // Battery level returned in devStatusAns messages
     u1_t        adrEnabled;
     u1_t        moreData;     // NWK has more data pending
 #if LMIC_ENABLE_TxParamSetupReq
@@ -694,6 +698,7 @@ void  LMIC_setPingable   (u1_t intvExp);
 void LMIC_setSession (u4_t netid, devaddr_t devaddr, xref2u1_t nwkKey, xref2u1_t artKey);
 void LMIC_setLinkCheckMode (bit_t enabled);
 void LMIC_setClockError(u2_t error);
+void LMIC_setBattLevel(u1_t battLevel);
 
 u4_t LMIC_getSeqnoUp    (void);
 u4_t LMIC_setSeqnoUp    (u4_t);
@@ -704,6 +709,7 @@ int LMIC_getNetworkTimeReference(lmic_time_reference_t *pReference);
 
 int LMIC_registerRxMessageCb(lmic_rxmessage_cb_t *pRxMessageCb, void *pUserData);
 int LMIC_registerEventCb(lmic_event_cb_t *pEventCb, void *pUserData);
+int LMIC_registerBattLevelCb(lmic_battlevel_cb_t *pBattLevelCb, void *pUserData);
 
 // APIs for client half of compliance.
 typedef u1_t lmic_compliance_rx_action_t;


### PR DESCRIPTION
This pull request is an extension of the PR #559, with the following changes:
1. os_getBattLevel() is kept in the code.
2. User installable callback is provided for configurations with LMIC_ENABLE_user_events setting
3. Plain setter function is provided for static or simple applications.
Callback takes precedence over static method.
