### PR TITLE
Add missing pinmap option

### DIFF
--- a/src/hal/getpinmap_thisboard.cpp
+++ b/src/hal/getpinmap_thisboard.cpp
@@ -55,6 +55,8 @@ const HalPinmap_t *GetPinmap_ThisBoard(void)
         return GetPinmap_Catena4630();
 #elif defined(ARDUINO_MCCI_CATENA_4801)
         return GetPinmap_Catena4801();
+#elif defined(ARDUINO_DISCO_L072CZ_LRWAN1)
+        return GetPinmap_Disco_L072cz_Lrwan1();
 #elif defined(PINNOCHIO_SCOUT)
         return GetPinmap_PinnochioScount();
 #elif defined(ARDUINO_TTGO_LoRa32_V1)


### PR DESCRIPTION
v3.1 adds this pinmap function, but doesn't select it if the board is selected.

Tested on `ST B-L072Z-LRWAN1`