### PR TITLE
Clean EU868 band for join

### DIFF
--- a/src/lmic/lmic_as923.c
+++ b/src/lmic/lmic_as923.c
@@ -173,9 +173,7 @@ static CONST_TABLE(u4_t, iniChannelFreq)[NUM_DEFAULT_CHANNELS] = {
         AS923_F2 | BAND_CENTI,
 };
 
-// as923 ignores join, becuase the channel setup is the same either way.
-void LMICas923_initDefaultChannels(bit_t join) {
-        LMIC_API_PARAMETER(join);
+void LMICas923_initDefaultChannels() {
 
         os_clearMem(&LMIC.channelFreq, sizeof(LMIC.channelFreq));
 #if !defined(DISABLE_MCMD_DlChannelReq)

--- a/src/lmic/lmic_bandplan_as923.h
+++ b/src/lmic/lmic_bandplan_as923.h
@@ -96,8 +96,8 @@ ostime_t LMICas923_nextTx(ostime_t now);
 ostime_t LMICas923_nextJoinState(void);
 #define LMICbandplan_nextJoinState()    LMICas923_nextJoinState()
 
-void LMICas923_initDefaultChannels(bit_t join);
-#define LMICbandplan_initDefaultChannels(join)  LMICas923_initDefaultChannels(join)
+void LMICas923_initDefaultChannels();
+#define LMICbandplan_initDefaultChannels()  LMICas923_initDefaultChannels()
 
 // override default for LMICbandplan_updateTX
 #undef LMICbandplan_updateTx

--- a/src/lmic/lmic_bandplan_eu868.h
+++ b/src/lmic/lmic_bandplan_eu868.h
@@ -78,8 +78,8 @@ ostime_t LMICeu868_nextTx(ostime_t now);
 ostime_t LMICeu868_nextJoinState(void);
 #define LMICbandplan_nextJoinState()    LMICeu868_nextJoinState()
 
-void LMICeu868_initDefaultChannels(bit_t join);
-#define LMICbandplan_initDefaultChannels(join)  LMICeu868_initDefaultChannels(join)
+void LMICeu868_initDefaultChannels();
+#define LMICbandplan_initDefaultChannels()  LMICeu868_initDefaultChannels()
 
 #undef LMICbandplan_nextJoinTime
 ostime_t LMICeu868_nextJoinTime(ostime_t now);

--- a/src/lmic/lmic_bandplan_in866.h
+++ b/src/lmic/lmic_bandplan_in866.h
@@ -75,8 +75,8 @@ ostime_t LMICin866_nextTx(ostime_t now);
 ostime_t LMICin866_nextJoinState(void);
 #define LMICbandplan_nextJoinState()    LMICin866_nextJoinState()
 
-void LMICin866_initDefaultChannels(bit_t join);
-#define LMICbandplan_initDefaultChannels(join)  LMICin866_initDefaultChannels(join)
+void LMICin866_initDefaultChannels();
+#define LMICbandplan_initDefaultChannels()  LMICin866_initDefaultChannels()
 
 void LMICin866_setRx1Params(void);
 #define LMICbandplan_setRx1Params()     LMICin866_setRx1Params()

--- a/src/lmic/lmic_bandplan_kr920.h
+++ b/src/lmic/lmic_bandplan_kr920.h
@@ -78,8 +78,8 @@ ostime_t LMICkr920_nextTx(ostime_t now);
 ostime_t LMICkr920_nextJoinState(void);
 #define LMICbandplan_nextJoinState()    LMICkr920_nextJoinState()
 
-void LMICkr920_initDefaultChannels(bit_t join);
-#define LMICbandplan_initDefaultChannels(join)  LMICkr920_initDefaultChannels(join)
+void LMICkr920_initDefaultChannels();
+#define LMICbandplan_initDefaultChannels()  LMICkr920_initDefaultChannels()
 
 void LMICkr920_setRx1Params(void);
 #define LMICbandplan_setRx1Params()     LMICkr920_setRx1Params()

--- a/src/lmic/lmic_eu868.c
+++ b/src/lmic/lmic_eu868.c
@@ -91,14 +91,16 @@ ostime_t LMICeu868_dr2hsym(uint8_t dr) {
 
 
 enum { NUM_DEFAULT_CHANNELS = 3 };
-static CONST_TABLE(u4_t, iniChannelFreq)[6] = {
-        // Join frequencies and duty cycle limit (0.1%)
-        EU868_F1 | BAND_MILLI, EU868_F2 | BAND_MILLI, EU868_F3 | BAND_MILLI,
+static CONST_TABLE(u4_t, iniChannelFreq)[NUM_DEFAULT_CHANNELS] = {
         // Default operational frequencies and duty cycle limit (1%)
-        EU868_F1 | BAND_CENTI, EU868_F2 | BAND_CENTI, EU868_F3 | BAND_CENTI,
+        EU868_F1 | BAND_CENTI,
+        EU868_F2 | BAND_CENTI,
+        EU868_F3 | BAND_CENTI,
 };
 
 void LMICeu868_initDefaultChannels(bit_t join) {
+        LMIC_API_PARAMETER(join);
+
         os_clearMem(&LMIC.channelFreq, sizeof(LMIC.channelFreq));
 #if !defined(DISABLE_MCMD_DlChannelReq)
         os_clearMem(&LMIC.channelDlFreq, sizeof(LMIC.channelDlFreq));
@@ -107,9 +109,8 @@ void LMICeu868_initDefaultChannels(bit_t join) {
         os_clearMem(&LMIC.bands, sizeof(LMIC.bands));
 
         LMIC.channelMap = (1 << NUM_DEFAULT_CHANNELS) - 1;
-        u1_t su = join ? 0 : NUM_DEFAULT_CHANNELS;
-        for (u1_t fu = 0; fu<NUM_DEFAULT_CHANNELS; fu++, su++) {
-                LMIC.channelFreq[fu] = TABLE_GET_U4(iniChannelFreq, su);
+        for (u1_t fu = 0; fu<NUM_DEFAULT_CHANNELS; fu++) {
+                LMIC.channelFreq[fu] = TABLE_GET_U4(iniChannelFreq, fu);
                 // TODO(tmm@mcci.com): don't use EU DR directly, use something from the LMIC context or a static const
                 LMIC.channelDrMap[fu] = DR_RANGE_MAP(EU868_DR_SF12, EU868_DR_SF7);
         }

--- a/src/lmic/lmic_eu868.c
+++ b/src/lmic/lmic_eu868.c
@@ -98,8 +98,7 @@ static CONST_TABLE(u4_t, iniChannelFreq)[NUM_DEFAULT_CHANNELS] = {
         EU868_F3 | BAND_CENTI,
 };
 
-void LMICeu868_initDefaultChannels(bit_t join) {
-        LMIC_API_PARAMETER(join);
+void LMICeu868_initDefaultChannels() {
 
         os_clearMem(&LMIC.channelFreq, sizeof(LMIC.channelFreq));
 #if !defined(DISABLE_MCMD_DlChannelReq)

--- a/src/lmic/lmic_eu_like.c
+++ b/src/lmic/lmic_eu_like.c
@@ -134,7 +134,7 @@ void LMICeulike_initJoinLoop(uint8_t nDefaultChannels, s1_t adrTxPow) {
         // TODO(tmm@mcci.com) don't use EU directly, use a table. That
         // will allow support for EU-style bandplans with similar code.
         LMICcore_setDrJoin(DRCHG_SET, LMICbandplan_getInitialDrJoin());
-        LMICbandplan_initDefaultChannels(/* put into join mode */ 1);
+        LMICbandplan_initDefaultChannels();
         ASSERT((LMIC.opmode & OP_NEXTCHNL) == 0);
         LMIC.txend = os_getTime() + LMICcore_rndDelay(8);
 }

--- a/src/lmic/lmic_eu_like.h
+++ b/src/lmic/lmic_eu_like.h
@@ -59,7 +59,7 @@ LMICeulike_isValidBeacon1(const uint8_t *d) {
 void LMICeulike_txDoneFSK(ostime_t delay, osjobcb_t func);
 #define LMICbandplan_txDoneFSK(delay, func)     LMICeulike_txDoneFSK(delay, func)
 
-#define LMICbandplan_joinAcceptChannelClear()   LMICbandplan_initDefaultChannels(/* normal, not join */ 0)
+#define LMICbandplan_joinAcceptChannelClear()   LMICbandplan_initDefaultChannels()
 
 enum { BAND_MILLI = 0, BAND_CENTI = 1, BAND_DECI = 2, BAND_AUX = 3 };
 
@@ -73,7 +73,7 @@ enum { BAND_MILLI = 0, BAND_CENTI = 1, BAND_DECI = 2, BAND_AUX = 3 };
         do { /* nothing */ } while (0)
 
 #define LMICbandplan_setSessionInitDefaultChannels()    \
-        do { LMICbandplan_initDefaultChannels(/* normal, not join */ 0); } while (0)
+        do { LMICbandplan_initDefaultChannels(); } while (0)
 
 bit_t LMICeulike_canMapChannels(u1_t chpage, u2_t chmap);
 #define LMICbandplan_canMapChannels(c, m)  LMICeulike_canMapChannels(c, m)

--- a/src/lmic/lmic_in866.c
+++ b/src/lmic/lmic_in866.c
@@ -100,9 +100,7 @@ static CONST_TABLE(u4_t, iniChannelFreq)[NUM_DEFAULT_CHANNELS] = {
         IN866_F3 | BAND_MILLI,
 };
 
-// india ignores join, becuase the channel setup is the same either way.
-void LMICin866_initDefaultChannels(bit_t join) {
-        LMIC_API_PARAMETER(join);
+void LMICin866_initDefaultChannels() {
 
         os_clearMem(&LMIC.channelFreq, sizeof(LMIC.channelFreq));
 #if !defined(DISABLE_MCMD_DlChannelReq)

--- a/src/lmic/lmic_kr920.c
+++ b/src/lmic/lmic_kr920.c
@@ -96,9 +96,7 @@ static CONST_TABLE(u4_t, iniChannelFreq)[NUM_DEFAULT_CHANNELS] = {
         KR920_F3 | BAND_MILLI,
 };
 
-// korea ignores the join flag, becuase the channel setup is the same either way.
-void LMICkr920_initDefaultChannels(bit_t join) {
-        LMIC_API_PARAMETER(join);
+void LMICkr920_initDefaultChannels() {
 
         os_clearMem(&LMIC.channelFreq, sizeof(LMIC.channelFreq));
 #if !defined(DISABLE_MCMD_DlChannelReq)

--- a/src/lmic/lmic_us_like.c
+++ b/src/lmic/lmic_us_like.c
@@ -80,8 +80,7 @@ bit_t LMIC_setupBand(u1_t bandidx, s1_t txpow, u2_t txcap) {
 }
 
 
-void LMICuslike_initDefaultChannels(bit_t fJoin) {
-        LMIC_API_PARAMETER(fJoin);
+void LMICuslike_initDefaultChannels() {
 
         // things work the same for join as normal.
         for (u1_t i = 0; i<4; i++)

--- a/src/lmic/lmic_us_like.h
+++ b/src/lmic/lmic_us_like.h
@@ -72,10 +72,10 @@ LMICuslike_isValidBeacon1(const uint8_t *d) {
 // TODO(tmm@mcci.com): decide whether we want to do this on every
 // reset or just restore the last sub-band selected by the user.
 #define LMICbandplan_resetDefaultChannels()     \
-        LMICbandplan_initDefaultChannels(/* normal */ 0)
+        LMICbandplan_initDefaultChannels()
 
-void LMICuslike_initDefaultChannels(bit_t fJoin);
-#define LMICbandplan_initDefaultChannels(fJoin) LMICuslike_initDefaultChannels(fJoin)
+void LMICuslike_initDefaultChannels();
+#define LMICbandplan_initDefaultChannels() LMICuslike_initDefaultChannels()
 
 #define LMICbandplan_setSessionInitDefaultChannels()    \
         do { /* nothing */} while (0)


### PR DESCRIPTION
⚠️ should only be merge after the implementation of a back off for joining request.

For joining, EU868 use  wrong band to limit the number of join request in case no gateway answer, see PR https://github.com/mcci-catena/arduino-lmic/pull/546#issuecomment-637846505.

This PR change to use the right band and remove the "join" parameter only used in EU868.