### PR TITLE
Fix spelling of name of author Matthijs Kooijman

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,6 +1,6 @@
 name=MCCI LoRaWAN LMIC library
 version=3.2.0
-author=IBM, Matthis Kooijman, Terry Moore, ChaeHee Won, Frank Rose
+author=IBM, Matthijs Kooijman, Terry Moore, ChaeHee Won, Frank Rose
 maintainer=Terry Moore <tmm@mcci.com>
 sentence=Arduino port of the LMIC (LoraWAN-MAC-in-C) framework provided by IBM.
 paragraph=Supports LoRaWAN 1.0.2/1.0.3 Class A devices implemented using the Semtech SX1272/SX1276 (including HopeRF RFM92/RFM95 and Murata modules). Support for EU868, US, AU, AS923, KR and IN regional plans. Untested support for Class B and FSK operation. Various enhancements and bug fixes from MCCI and The Things Network New York. Original IBM URL http://www.research.ibm.com/labs/zurich/ics/lrsc/lmic.html.


### PR DESCRIPTION
Trivial fix. This fixes the spelling of the name of Matthijs Kooijman in the library.properties file.