### PR TITLE
Implemented LMIC Secure Element APIs to get session keys and modified data length for aes_appendMic()

### DIFF
--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -1553,8 +1553,8 @@ static bit_t processJoinAccept (void) {
     if (seErr != LMIC_SecureElement_Error_OK)
         return processJoinAccept_badframe();
     
-    LMIC_SecureElement_getAppSKey(&AppSKey, 0);
-    LMIC_SecureElement_getNwkSKey(&NwkSKey, 0);
+    LMIC_SecureElement_getAppSKey(&AppSKey, LMIC_SecureElement_KeySelector_Unicast);
+    LMIC_SecureElement_getNwkSKey(&NwkSKey, LMIC_SecureElement_KeySelector_Unicast);
 
     memcpy(LMIC.artKey, AppSKey.bytes, sizeof(LMIC.artKey));
     memcpy(LMIC.nwkKey, NwkSKey.bytes, sizeof(LMIC.nwkKey));

--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -1542,7 +1542,6 @@ static bit_t processJoinAccept (void) {
     }
 
     LMIC_SecureElement_Error_t seErr;
-    LMIC_SecureElement_Aes128Key_t AppSKey, NwkSKey;
     
     seErr = LMIC_SecureElement_Default_decodeJoinAccept(
         LMIC.frame, dlen,
@@ -1552,12 +1551,6 @@ static bit_t processJoinAccept (void) {
 
     if (seErr != LMIC_SecureElement_Error_OK)
         return processJoinAccept_badframe();
-    
-    LMIC_SecureElement_getAppSKey(&AppSKey, LMIC_SecureElement_KeySelector_Unicast);
-    LMIC_SecureElement_getNwkSKey(&NwkSKey, LMIC_SecureElement_KeySelector_Unicast);
-
-    memcpy(LMIC.artKey, AppSKey.bytes, sizeof(LMIC.artKey));
-    memcpy(LMIC.nwkKey, NwkSKey.bytes, sizeof(LMIC.nwkKey));
 
     u4_t addr = os_rlsbf4(LMIC.frame+OFF_JA_DEVADDR);
     LMIC.devaddr = addr;
@@ -3005,10 +2998,14 @@ u4_t LMIC_setSeqnoUp(u4_t seq_no) {
 
 // \brief return the current session keys returned from join.
 void LMIC_getSessionKeys (u4_t *netid, devaddr_t *devaddr, xref2u1_t nwkKey, xref2u1_t artKey) {
+    LMIC_SecureElement_Aes128Key_t AppSKey, NwkSKey;
     *netid = LMIC.netid;
     *devaddr = LMIC.devaddr;
-    memcpy(artKey, LMIC.artKey, sizeof(LMIC.artKey));
-    memcpy(nwkKey, LMIC.nwkKey, sizeof(LMIC.nwkKey));
+
+    LMIC_SecureElement_getAppSKey(&AppSKey, LMIC_SecureElement_KeySelector_Unicast);
+    LMIC_SecureElement_getNwkSKey(&NwkSKey, LMIC_SecureElement_KeySelector_Unicast);
+    memcpy(artKey, AppSKey.bytes, sizeof(AppSKey.bytes));
+    memcpy(nwkKey, NwkSKey.bytes, sizeof(NwkSKey.bytes));
 }
 
 // \brief post an asynchronous request for the network time.

--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -1542,6 +1542,7 @@ static bit_t processJoinAccept (void) {
     }
 
     LMIC_SecureElement_Error_t seErr;
+    LMIC_SecureElement_Aes128Key_t AppSKey, NwkSKey;
     
     seErr = LMIC_SecureElement_Default_decodeJoinAccept(
         LMIC.frame, dlen,
@@ -1551,6 +1552,12 @@ static bit_t processJoinAccept (void) {
 
     if (seErr != LMIC_SecureElement_Error_OK)
         return processJoinAccept_badframe();
+    
+    LMIC_SecureElement_getAppSKey(&AppSKey, 0);
+    LMIC_SecureElement_getNwkSKey(&NwkSKey, 0);
+
+    memcpy(LMIC.artKey, AppSKey.bytes, sizeof(LMIC.artKey));
+    memcpy(LMIC.nwkKey, NwkSKey.bytes, sizeof(LMIC.nwkKey));
 
     u4_t addr = os_rlsbf4(LMIC.frame+OFF_JA_DEVADDR);
     LMIC.devaddr = addr;

--- a/src/se/drivers/default/lmic_se_default.c
+++ b/src/se/drivers/default/lmic_se_default.c
@@ -154,6 +154,8 @@ In this function the nwkskey is passed to upper layer of LMIC.
 
 LMIC_SecureElement_Error_t
 LMIC_SecureElement_Default_getNwkSKey(LMIC_SecureElement_Aes128Key_t *pNwkSKey, LMIC_SecureElement_KeySelector_t iKey) {
+    if (iKey != LMIC_SecureElement_KeySelector_Unicast)
+        return LMIC_SecureElement_Error_InvalidParameter;
     os_copyMem(pNwkSKey->bytes, s_nwkSKey.bytes, sizeof(pNwkSKey->bytes));
 }
 
@@ -169,6 +171,8 @@ In this function the appskey is passed to upper layer of LMIC.
 
 LMIC_SecureElement_Error_t
 LMIC_SecureElement_Default_getAppSKey(LMIC_SecureElement_Aes128Key_t *pAppSKey, LMIC_SecureElement_KeySelector_t iKey) {
+    if (iKey != LMIC_SecureElement_KeySelector_Unicast)
+        return LMIC_SecureElement_Error_InvalidParameter;
     os_copyMem(pAppSKey->bytes, s_appSKey.bytes, sizeof(pAppSKey->bytes));
 }
 

--- a/src/se/drivers/default/lmic_se_default.c
+++ b/src/se/drivers/default/lmic_se_default.c
@@ -154,7 +154,7 @@ In this function the nwkskey is passed to upper layer of LMIC.
 
 LMIC_SecureElement_Error_t
 LMIC_SecureElement_Default_getNwkSKey(LMIC_SecureElement_Aes128Key_t *pNwkSKey, LMIC_SecureElement_KeySelector_t iKey) {
-    os_copyMem(pNwkSKey->bytes,s_nwkSKey.bytes, 16);
+    os_copyMem(pNwkSKey->bytes, s_nwkSKey.bytes, sizeof(pNwkSKey->bytes));
 }
 
 /*!
@@ -169,7 +169,7 @@ In this function the appskey is passed to upper layer of LMIC.
 
 LMIC_SecureElement_Error_t
 LMIC_SecureElement_Default_getAppSKey(LMIC_SecureElement_Aes128Key_t *pAppSKey, LMIC_SecureElement_KeySelector_t iKey) {
-    os_copyMem(pAppSKey->bytes,s_appSKey.bytes, 16);
+    os_copyMem(pAppSKey->bytes, s_appSKey.bytes, sizeof(pAppSKey->bytes));
 }
 
 // ================================================================================

--- a/src/se/drivers/default/lmic_se_default.c
+++ b/src/se/drivers/default/lmic_se_default.c
@@ -142,6 +142,36 @@ LMIC_SecureElement_Default_setAppKey(const LMIC_SecureElement_Aes128Key_t *pAppK
     return LMIC_SecureElement_Error_OK;
 }
 
+/*!
+
+\copydoc LMIC_SecureElement_getNwkSKey_t
+
+\par "Implementation Notes"
+In the default secure element, the nwkskey is stored in a static variable without obfuscation.
+In this function the nwkskey is passed to upper layer of LMIC.
+
+*/
+
+LMIC_SecureElement_Error_t
+LMIC_SecureElement_Default_getNwkSKey(LMIC_SecureElement_Aes128Key_t *pNwkSKey, LMIC_SecureElement_KeySelector_t iKey) {
+    os_copyMem(pNwkSKey->bytes,s_nwkSKey.bytes, 16);
+}
+
+/*!
+
+\copydoc LMIC_SecureElement_getAppSKey_t
+
+\par "Implementation Notes"
+In the default secure element, the appskey is stored in a static variable without obfuscation.
+In this function the appskey is passed to upper layer of LMIC.
+
+*/
+
+LMIC_SecureElement_Error_t
+LMIC_SecureElement_Default_getAppSKey(LMIC_SecureElement_Aes128Key_t *pAppSKey, LMIC_SecureElement_KeySelector_t iKey) {
+    os_copyMem(pAppSKey->bytes,s_appSKey.bytes, 16);
+}
+
 // ================================================================================
 // BEG AES
 
@@ -265,7 +295,7 @@ LMIC_SecureElement_Default_encodeMessage(
         LMIC.seqnoUp - 1,
         /*up*/ 0,
         pCipherTextBuffer,
-        nMessage
+        nData
         );
     return LMIC_SecureElement_Error_OK;
 }


### PR DESCRIPTION
Able to send packets to the network, with modifying the data length of aes_appendMic(). Also able to get the session keys in the upper LMIC layer.