### PR TITLE
fix: only set SF9 for RX2 when using EU868

### DIFF
--- a/examples/ttn-abp-feather-us915-dht22/ttn-abp-feather-us915-dht22.ino
+++ b/examples/ttn-abp-feather-us915-dht22/ttn-abp-feather-us915-dht22.ino
@@ -260,9 +260,6 @@ void setup() {
     // Disable link check validation
     LMIC_setLinkCheckMode(0);
 
-    // TTN uses SF9 for its RX2 window.
-    LMIC.dn2Dr = DR_SF9;
-
     // Set data rate and transmit power for uplink
     LMIC_setDrTxpow(DR_SF7,14);
 

--- a/examples/ttn-abp/ttn-abp.ino
+++ b/examples/ttn-abp/ttn-abp.ino
@@ -252,6 +252,9 @@ void setup() {
     // devices' ping slots. LMIC does not have an easy way to define set this
     // frequency and support for class B is spotty and untested, so this
     // frequency is not configured here.
+
+    // In EU868, TTN uses SF9 for its RX2 window.
+    LMIC.dn2Dr = DR_SF9;
     #elif defined(CFG_us915) || defined(CFG_au915)
     // NA-US and AU channels 0-71 are configured automatically
     // but only one group of 8 should (a subband) should be active
@@ -289,9 +292,6 @@ void setup() {
 
     // Disable link check validation
     LMIC_setLinkCheckMode(0);
-
-    // TTN uses SF9 for its RX2 window.
-    LMIC.dn2Dr = DR_SF9;
 
     // Set data rate and transmit power for uplink
     LMIC_setDrTxpow(DR_SF7,14);


### PR DESCRIPTION
The ABP examples used the following line regardless the frequency plan:

```cpp
// TTN uses SF9 for its RX2 window.
LMIC.dn2Dr = DR_SF9;
```

However, [this only applies to EU868](https://www.thethingsnetwork.org/docs/lorawan/frequency-plans.html). These small changes moves this into the `#if defined(CFG_eu868)` part for the generic ABP example, and removes it altogether from the US915-specific ABP example.