### PR TITLE
Remove unused room from AESKEY variable

### DIFF
--- a/src/aes/other.c
+++ b/src/aes/other.c
@@ -34,9 +34,9 @@
 // This should be defined elsewhere
 void lmic_aes_encrypt(u1_t *data, u1_t *key);
 
-// global area for passing parameters (aux, key) and for storing round keys
+// global area for passing parameters (aux, key)
 u4_t AESAUX[16/sizeof(u4_t)];
-u4_t AESKEY[11*16/sizeof(u4_t)];
+u4_t AESKEY[16/sizeof(u4_t)];
 
 // Shift the given buffer left one bit
 static void shift_left(xref2u1_t buf, u1_t len) {


### PR DESCRIPTION
The original LMIC AES implementation uses this variable to store
10x16 bytes of round keys, but for the other implementations (only
IDEETRON right now) this is only used to store the main key. In the
latter case, this variable only needs to be 16 bytes long, saving 160
bytes of RAM.

This commit has been part of my arduino-lmic version since 2017, but seems it was never ported to this version.