### PR TITLE
Allow configuring maximum frame length more precisely

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,7 +406,11 @@ All reference to `onEvent()` can be suppressed by setting `LMIC_ENABLE_onEvent` 
 
 #### Enabling long messages
 
-To save RAM for simple devices, the LMIC allows message length to be limited to 64 bytes instead of the LoRaWAN standard of 255 bytes max. This saves about 2*192 bytes of RAM. Unfortunately, compliance tests require the full message size. Long messages are enabled by setting `LMIC_ENABLE_long_messages` to 1, or disabled by setting it to zero. This C preprocessor macro is always defined as a post-condition of `#include "config.h"`; if non-zero, the maximum frame size is 255 bytes, and if zero, the maximum frame size is 64 bytes.
+By default, LMIC allows messages up to 255 bytes, as defined in the LoRaWAN standard and required by compliance testing. To save RAM for simple devices, this can be limited using the `LMIC_MAX_FRAME_LENGTH` macro. This macro defines the length of the full frame, the maximum payload size is a bit smaller (and can be read from the `MAX_LEN_PAYLOAD` constant).
+
+This value controls both the TX and RX buffers, so reducing it by 1 saves 2 bytes of RAM. The value should be not be set too small, since that can prevent properly receiving network downlinks (e.g. join accepts or MAC commands). Using `#define LMIC_MAX_FRAME_LENGTH 64` is common and should be big enough for most operation, while saving 384 bytes of RAM.
+
+Originally, this was configured using the `LMIC_ENABLE_long_messages` macro, which is still supported for compatibility. Setting `LMIC_ENABLE_long_messages` to 0 is equivalent to setting `LMIC_MAX_FRAME_LENGTH` to 64.
 
 #### Enabling LMIC event logging calls
 

--- a/src/lmic/config.h
+++ b/src/lmic/config.h
@@ -187,9 +187,17 @@
 #endif
 
 // LMIC_ENABLE_long_messages
-// LMIC certification requires that this be enabled.
-#if !defined(LMIC_ENABLE_long_messages)
-# define LMIC_ENABLE_long_messages 1        /* PARAM */
+// LMIC certification requires full-length 255 frames, but to save RAM,
+// a shorter maximum can be set. This controls both RX and TX buffers,
+// so reducing this by 1 saves 2 bytes of RAM.
+#if defined(LMIC_ENABLE_long_messages) && defined(LMIC_MAX_FRAME_LENGTH)
+#error "Use only one of LMIC_ENABLE_long_messages or LMIC_MAX_FRAME_LENGTH"
+#elif defined(LMIC_ENABLE_long_messages) && LMIC_ENABLE_long_messages == 0
+# define LMIC_MAX_FRAME_LENGTH 64
+#elif !defined(LMIC_MAX_FRAME_LENGTH)
+# define LMIC_MAX_FRAME_LENGTH 255
+#elif LMIC_MAX_FRAME_LENGTH > 255
+#error "LMIC_MAX_FRAME_LENGTH cannot be larger than 255"
 #endif
 
 // LMIC_ENABLE_event_logging

--- a/src/lmic/lorabase.h
+++ b/src/lmic/lorabase.h
@@ -60,7 +60,7 @@ enum { ILLEGAL_RPS = 0xFF };
 
 // Global maximum frame length
 enum { STD_PREAMBLE_LEN  =  8 };
-enum { MAX_LEN_FRAME     =  LMIC_ENABLE_long_messages ? 255 : 64 };
+enum { MAX_LEN_FRAME     =  LMIC_MAX_FRAME_LENGTH };
 enum { LEN_DEVNONCE      =  2 };
 enum { LEN_ARTNONCE      =  3 };
 enum { LEN_NETID         =  3 };


### PR DESCRIPTION
This deprecates the `LMIC_ENABLE_long_messages` configuration macro and
allows configuring LMIC_MAX_FRAME_LENGTH instead, allowing a more
fine-grained balance between memory usage and maximum frame length.


I originally started this because I was a bit confused with the documentation for `LMIC_ENABLE_long_messages` (it wasn't entirely clear what the default setting was), but while rewriting the README entry about this, I realized it was weird that you could only choose between two maximum sizes, when there's no technical reason (that I could see) to limit this to specific values (other than that the value should not be too small).