### PR TITLE
Ability to disable RSSI-based random number generator in radio.c

### DIFF
--- a/src/lmic/config.h
+++ b/src/lmic/config.h
@@ -151,6 +151,14 @@
 # error "You may define at most one of USE_ORIGINAL_AES and USE_IDEETRON_AES"
 #endif
 
+
+// By default LMIC use the radio to gather random seed from wideband RSSI
+// measurements. Extracting good quality random seed takes 480 SPI transactions
+// on average. This flag allows alternative random implementations, like
+// true-RNGs built-in to many MCUs. Use in conjuction with os_getRndU1.
+// define this in lmic_project_config.h to disable radio.c random number generator
+//#define LMIC_DISABLE_RADIO_RAND
+
 // LMIC_DISABLE_DR_LEGACY
 // turn off legacy DR_* symbols that vary by bandplan.
 // Older code uses these for configuration. EU868_DR_*, US915_DR_*

--- a/src/lmic/oslmic.h
+++ b/src/lmic/oslmic.h
@@ -92,9 +92,6 @@ extern u4_t AESKEY[];
 #define AESaux ((u1_t*)AESAUX)
 #define FUNC_ADDR(func) (&(func))
 
-u1_t radio_rand1 (void);
-#define os_getRndU1() radio_rand1()
-
 #define DEFINE_LMIC  struct lmic_t LMIC
 #define DECLARE_LMIC extern struct lmic_t LMIC
 
@@ -114,6 +111,7 @@ void os_init (void);
 int os_init_ex (const void *pPinMap);
 void os_runloop (void);
 void os_runloop_once (void);
+u1_t radio_rand1 (void);
 u1_t radio_rssi (void);
 void radio_monitor_rssi(ostime_t n, oslmic_radio_rssi_t *pRssi);
 
@@ -222,7 +220,7 @@ bit_t os_queryTimeCriticalJobs(ostime_t time);
 u4_t os_rlsbf4 (xref2cu1_t buf);
 #endif
 #ifndef os_wlsbf4
-//! Write 32-bit quntity into buffer in little endian byte order.
+//! Write 32-bit quantity into buffer in little endian byte order.
 void os_wlsbf4 (xref2u1_t buf, u4_t value);
 #endif
 #ifndef os_rmsbf4
@@ -230,7 +228,7 @@ void os_wlsbf4 (xref2u1_t buf, u4_t value);
 u4_t os_rmsbf4 (xref2cu1_t buf);
 #endif
 #ifndef os_wmsbf4
-//! Write 32-bit quntity into buffer in big endian byte order.
+//! Write 32-bit quantity into buffer in big endian byte order.
 void os_wmsbf4 (xref2u1_t buf, u4_t value);
 #endif
 #ifndef os_rlsbf2
@@ -238,10 +236,14 @@ void os_wmsbf4 (xref2u1_t buf, u4_t value);
 u2_t os_rlsbf2 (xref2cu1_t buf);
 #endif
 #ifndef os_wlsbf2
-//! Write 16-bit quntity into buffer in little endian byte order.
+//! Write 16-bit quantity into buffer in little endian byte order.
 void os_wlsbf2 (xref2u1_t buf, u2_t value);
 #endif
 
+//! Get random number (default impl for u1_t).
+#ifndef os_getRndU1
+#define os_getRndU1() radio_rand1()
+#endif
 //! Get random number (default impl for u2_t).
 #ifndef os_getRndU2
 #define os_getRndU2() ((u2_t)((os_getRndU1()<<8)|os_getRndU1()))


### PR DESCRIPTION
This PR allows library users to disable the random number generator in `radio.c` and replace it with a custom one.

LoRaWAN 1.0 specs requires `DevNonce` to be a random number. The specs asks specifically a high quality random and proposes the wideband RSSI measurement as a random source ("The `DevNonce` can be extracted by issuing a sequence of RSSI measurements under the assumption that the quality of randomness fulfills the criteria of true randomness").

LMIC library implements exactly that. The implementation seeds its random number generator with 120 random bits using RSSI measurement and von Neumann random extraction technique. This requires at least, on average 480 SPI read operations to `LORARegRssiWideband` register, while the radio is kept in `RXMODE_RSSI`.

On my implementation (STM32L4 + ST-provided HAL functions for SPI) seeding the RNG takes about 150ms. As the radio is kept powered down by default, it is a huge burden on each re-init, especially since many MCU's have built-in true-RNGs (which completes in my case in ~50 CPU cycles).

What changed?
* added a new flag (`LMIC_DISABLE_RADIO_RAND`) to completely disable the random number generator in `radio.c`
* re-organised the code in `oslmic.h`, moved `u1_t radio_rand1 (void);` from a seemingly random location next to other os/radio related definitions.
* `#define os_getRndU1() radio_rand1()` moved next to other os defines, in a similar manner as the rest os-related defines are created
* fixed some typos meanwhile + added comment where I felt missing.