### PR TITLE
MAX EIRP is 13dBm (= 19.95mW < 20mW) in as923jp

### DIFF
--- a/project_config/lmic_project_config.h
+++ b/project_config/lmic_project_config.h
@@ -3,7 +3,7 @@
 #define CFG_us915 1
 //#define CFG_au915 1
 //#define CFG_as923 1
-// #define LMIC_COUNTRY_CODE LMIC_COUNTRY_CODE_JP	/* for as923-JP */
+//#define CFG_as923jp 1
 //#define CFG_kr920 1
 //#define CFG_in866 1
 #define CFG_sx1276_radio 1

--- a/src/lmic/lorabase_as923.h
+++ b/src/lmic/lorabase_as923.h
@@ -68,7 +68,11 @@ enum {
         AS923_FREQ_MAX = 928000000
 };
 enum {
+#if defined(CFG_as923jp)
+        AS923_TX_EIRP_MAX_DBM = 13      // 13 dBm = 19.95mW < 20mW
+#else
         AS923_TX_EIRP_MAX_DBM = 16      // 16 dBm
+#endif
 };
 enum { DR_PAGE_AS923 = 0x10 * (LMIC_REGION_as923 - 1) };
 


### PR DESCRIPTION
16dBm is used as MAX EIRP when using OTAA in as923. However MAX EIRP is 13dBm in as923jp.