### PR TITLE
Support for TTGO-LoRa32-v2.1.6

### DIFF
--- a/src/hal/getpinmap_thisboard.cpp
+++ b/src/hal/getpinmap_thisboard.cpp
@@ -55,14 +55,14 @@ const HalPinmap_t *GetPinmap_ThisBoard(void)
         return GetPinmap_Catena4630();
 #elif defined(ARDUINO_MCCI_CATENA_4801)
         return GetPinmap_Catena4801();
-#elif defined(ARDUINO_MCCI_CATENA_4802)
-        return GetPinmap_Catena4802();
 #elif defined(ARDUINO_DISCO_L072CZ_LRWAN1)
         return GetPinmap_Disco_L072cz_Lrwan1();
 #elif defined(PINNOCHIO_SCOUT)
         return GetPinmap_PinnochioScount();
 #elif defined(ARDUINO_TTGO_LoRa32_V1)
         return GetPinmap_ttgo_lora32_v1();
+#elif defined(ARDUINO_TTGO_LoRa32_v21new)
+        return GetPinmap_ttgo_lora32_v21();
 #elif defined(ARDUINO_HELTEC_WIFI_LORA_32) || defined(ARDUINO_HELTEC_WIFI_LORA_32_V2) || defined(ARDUINO_HELTEC_WIRELESS_STICK)
         return GetPinmap_heltec_lora32();
 #else

--- a/src/hal/getpinmap_thisboard.cpp
+++ b/src/hal/getpinmap_thisboard.cpp
@@ -55,6 +55,8 @@ const HalPinmap_t *GetPinmap_ThisBoard(void)
         return GetPinmap_Catena4630();
 #elif defined(ARDUINO_MCCI_CATENA_4801)
         return GetPinmap_Catena4801();
+#elif defined(ARDUINO_MCCI_CATENA_4802)
+	return GetPinmap_Catena4802();
 #elif defined(ARDUINO_DISCO_L072CZ_LRWAN1)
         return GetPinmap_Disco_L072cz_Lrwan1();
 #elif defined(PINNOCHIO_SCOUT)

--- a/src/hal/getpinmap_ttgo_lora32_v2.1.cpp
+++ b/src/hal/getpinmap_ttgo_lora32_v2.1.cpp
@@ -1,0 +1,67 @@
+
+
+#include <arduino_lmic_hal_boards.h>
+#include <Arduino.h>
+
+#include "../lmic/oslmic.h"
+
+#define LORA_DIO0 26
+#define LORA_DIO1 33
+#define LORA_DIO2 32
+
+namespace Arduino_LMIC {
+
+class HalConfiguration_ttgo_lora32_v21 : public HalConfiguration_t
+	{
+public:
+	enum DIGITAL_PINS : uint8_t
+		{
+		PIN_SX1276_NSS = 18,
+		PIN_SX1276_NRESET = 23,
+		PIN_SX1276_DIO0 = LORA_DIO0,
+		PIN_SX1276_DIO1 = LORA_DIO1,
+		PIN_SX1276_DIO2 = LORA_DIO2,
+		PIN_SX1276_ANT_SWITCH_RX = HalPinmap_t::UNUSED_PIN,
+		PIN_SX1276_ANT_SWITCH_TX_BOOST = HalPinmap_t::UNUSED_PIN,
+		PIN_SX1276_ANT_SWITCH_TX_RFO = HalPinmap_t::UNUSED_PIN,
+		PIN_VDD_BOOST_ENABLE = HalPinmap_t::UNUSED_PIN,
+		};
+
+	virtual void begin(void) override
+		{
+		digitalWrite(PIN_SX1276_NSS, 1);
+		pinMode(PIN_SX1276_NSS, OUTPUT);
+		}
+
+	// virtual void end(void) override
+
+	// virtual ostime_t setModuleActive(bool state) override
+
+	};
+
+static HalConfiguration_ttgo_lora32_v21 myConfig;
+
+static const HalPinmap_t myPinmap =
+        {
+        .nss = HalConfiguration_ttgo_lora32_v21::PIN_SX1276_NSS,      // chip select is D7
+        .rxtx = HalConfiguration_ttgo_lora32_v21::PIN_SX1276_ANT_SWITCH_RX, // RXTX is D29
+        .rst = HalConfiguration_ttgo_lora32_v21::PIN_SX1276_NRESET,   // NRESET is D8
+
+        .dio = {HalConfiguration_ttgo_lora32_v21::PIN_SX1276_DIO0,    // DIO0 (IRQ) is D25
+				HalConfiguration_ttgo_lora32_v21::PIN_SX1276_DIO1,    // DIO1 is D26
+				HalConfiguration_ttgo_lora32_v21::PIN_SX1276_DIO2,    // DIO2 is D27
+               },
+        .rxtx_rx_active = 0,
+        .rssi_cal = 10,
+        .spi_freq = 8000000,     /* 8MHz */
+        .pConfig = &myConfig
+        };
+
+const HalPinmap_t * GetPinmap_ttgo_lora32_v21 (void)
+	{
+	return &myPinmap;
+	}
+
+}; // namespace Arduino_LMIC
+
+    


### PR DESCRIPTION
Added configuration for TTGO-LoRa32-v2.1.6; 
works with latest arduino-esp32 package for Arduino. I've tested
```
Arduino settings: Tools->ESP32 Arduino->TTGO-LoRa32-v2.1.6.
```
