### PR TITLE
Warning message for feather 32u4 pin mapping

### DIFF
--- a/examples/raw-feather/raw-feather.ino
+++ b/examples/raw-feather/raw-feather.ino
@@ -76,6 +76,8 @@ const lmic_pinmap lmic_pins = {
 // Just like Feather M0 LoRa, but uses SPI at 1MHz; and that's only
 // because MCCI doesn't have a test board; probably higher frequencies
 // will work.
+// /!\ By default Feather 32u4's pin 6 and DIO1 are not connected. Please 
+// ensure they are connected.
 const lmic_pinmap lmic_pins = {
     .nss = 8,
     .rxtx = LMIC_UNUSED_PIN,

--- a/examples/ttn-otaa-feather-us915/ttn-otaa-feather-us915.ino
+++ b/examples/ttn-otaa-feather-us915/ttn-otaa-feather-us915.ino
@@ -95,6 +95,8 @@ const lmic_pinmap lmic_pins = {
 // Just like Feather M0 LoRa, but uses SPI at 1MHz; and that's only
 // because MCCI doesn't have a test board; probably higher frequencies
 // will work.
+// /!\ By default Feather 32u4's pin 6 and DIO1 are not connected. Please 
+// ensure they are connected.
 const lmic_pinmap lmic_pins = {
     .nss = 8,
     .rxtx = LMIC_UNUSED_PIN,


### PR DESCRIPTION
Related to issue #695 

By default Feather 32u4's pin 6 and DIO1 are not connected. Add a warn message in comments for users