### PR TITLE
Warning message for Adafruit Feather M0 pin mapping

### DIFF
--- a/examples/helium-otaa/helium-otaa.ino
+++ b/examples/helium-otaa/helium-otaa.ino
@@ -12,6 +12,8 @@
  * world!", using frequency and encryption settings matching those of
  * the The Things Network. It's pre-configured for the Adafruit
  * Feather M0 LoRa.
+ * /!\ By default Adafruit Feather M0's pin 6 and DIO1 are not connected.
+ * Please ensure they are connected.
  *
  * This uses OTAA (Over-the-air activation), where where a DevEUI and
  * application key is configured, which are used in an over-the-air

--- a/examples/raw-feather/raw-feather.ino
+++ b/examples/raw-feather/raw-feather.ino
@@ -62,6 +62,8 @@ Author:
 // m0 defs ADAFRUIT_FEATHER_M0
 //
 #if defined(ARDUINO_SAMD_FEATHER_M0) || defined(ADAFRUIT_FEATHER_M0)
+// /!\ By default Adafruit Feather M0's pin 6 and DIO1 are not connected.
+// Please ensure they are connected.
 const lmic_pinmap lmic_pins = {
     .nss = 8,
     .rxtx = LMIC_UNUSED_PIN,

--- a/examples/raw-halconfig/raw-halconfig.ino
+++ b/examples/raw-halconfig/raw-halconfig.ino
@@ -4,6 +4,8 @@ Module:  raw-halconfig.ino
 
 Function:
   Auto-configured raw test example, for Adafruit Feather M0 LoRa
+  /!\ By default Adafruit Feather M0's pin 6 and DIO1 are not connected.
+  Please ensure they are connected.
 
 Copyright notice and License:
   See LICENSE file accompanying this project.

--- a/examples/ttn-abp-feather-us915-dht22/ttn-abp-feather-us915-dht22.ino
+++ b/examples/ttn-abp-feather-us915-dht22/ttn-abp-feather-us915-dht22.ino
@@ -76,6 +76,8 @@ static osjob_t sendjob;
 const unsigned TX_INTERVAL = 30;
 
 // Pin mapping for Adafruit Feather M0 LoRa
+// /!\ By default Adafruit Feather M0's pin 6 and DIO1 are not connected.
+// Please ensure they are connected.
 const lmic_pinmap lmic_pins = {
     .nss = 8,
     .rxtx = LMIC_UNUSED_PIN,

--- a/examples/ttn-otaa-feather-us915-dht22/ttn-otaa-feather-us915-dht22.ino
+++ b/examples/ttn-otaa-feather-us915-dht22/ttn-otaa-feather-us915-dht22.ino
@@ -67,6 +67,8 @@ static osjob_t sendjob;
 const unsigned TX_INTERVAL = 30;
 
 // Pin mapping for Adafruit Feather M0 LoRa
+// /!\ By default Adafruit Feather M0's pin 6 and DIO1 are not connected.
+// Please ensure they are connected.
 const lmic_pinmap lmic_pins = {
     .nss = 8,
     .rxtx = LMIC_UNUSED_PIN,

--- a/examples/ttn-otaa-feather-us915/ttn-otaa-feather-us915.ino
+++ b/examples/ttn-otaa-feather-us915/ttn-otaa-feather-us915.ino
@@ -81,6 +81,8 @@ const unsigned TX_INTERVAL = 60;
 //
 #if defined(ARDUINO_SAMD_FEATHER_M0) || defined(ADAFRUIT_FEATHER_M0)
 // Pin mapping for Adafruit Feather M0 LoRa, etc.
+// /!\ By default Adafruit Feather M0's pin 6 and DIO1 are not connected.
+// Please ensure they are connected.
 const lmic_pinmap lmic_pins = {
     .nss = 8,
     .rxtx = LMIC_UNUSED_PIN,

--- a/examples/ttn-otaa-halconfig-us915/ttn-otaa-halconfig-us915.ino
+++ b/examples/ttn-otaa-halconfig-us915/ttn-otaa-halconfig-us915.ino
@@ -12,6 +12,8 @@
  * world!", using frequency and encryption settings matching those of
  * the The Things Network. It's pre-configured for the Adafruit
  * Feather M0 LoRa.
+ * /!\ By default Adafruit Feather M0's pin 6 and DIO1 are not connected.
+ * Please ensure they are connected.
  *
  * This uses OTAA (Over-the-air activation), where where a DevEUI and
  * application key is configured, which are used in an over-the-air


### PR DESCRIPTION
By default Adafruit Feather M0's pin 6 and DIO1 are not connected.
Add a warn message in comments for users.
Similar to #703 and related to https://github.com/mcci-catena/arduino-lorawan/issues/166


