### PR TITLE
Proposal: add `hal_jump_to_the_future_us(usec)`

### DIFF
--- a/src/hal/hal.cpp
+++ b/src/hal/hal.cpp
@@ -223,6 +223,12 @@ static void hal_time_init () {
     // Nothing to do
 }
 
+uint32_t delta_ticks = 0;
+void hal_jump_to_the_future_us (uint32_t us) {
+    delta_ticks += us >> US_PER_OSTICK_EXPONENT;
+    //overflow += 
+}
+
 u4_t hal_ticks () {
     // Because micros() is scaled down in this function, micros() will
     // overflow before the tick timer should, causing the tick timer to
@@ -248,6 +254,7 @@ u4_t hal_ticks () {
     // Scaled down timestamp. The top US_PER_OSTICK_EXPONENT bits are 0,
     // the others will be the lower bits of our return value.
     uint32_t scaled = micros() >> US_PER_OSTICK_EXPONENT;
+    scaled += delta_ticks;
     // Most significant byte of scaled
     uint8_t msb = scaled >> 24;
     // Mask pointing to the overlapping bit in msb and overflow.

--- a/src/lmic/hal.h
+++ b/src/lmic/hal.h
@@ -180,6 +180,8 @@ static void inline hal_pollPendingIRQs(void)
 #endif /* !defined(LMIC_USE_INTERRUPTS) */
 	}
 
+void hal_jump_to_the_future_us (uint32_t us);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/src/lmic/hal.h
+++ b/src/lmic/hal.h
@@ -180,7 +180,9 @@ static void inline hal_pollPendingIRQs(void)
 #endif /* !defined(LMIC_USE_INTERRUPTS) */
 	}
 
+#if defined(HAL_ALLOW_FUTURE_JUMP)
 void hal_jump_to_the_future_us (uint32_t us);
+#endif
 
 #ifdef __cplusplus
 } // extern "C"


### PR DESCRIPTION
When MCU is put in sleep mode, `micros()` can be not updated.
A new config function `hal_jump_to_the_future_us(usec)` is proposed to tell HAL that we just woke up in the future.
It is not enabled by default, and is conditioned by the macro `HAL_ALLOW_FUTURE_JUMP`.

There might be a hiccup when `micros()` and `delta_us` overflow both at the same time (between two calls to `hal_ticks()`).
A valid workaround might be to call `hal_ticks()` from within `hal_jump_to_the_future_us()` just before and after updating `delta_usec`.