### PR TITLE
Fix #763: use TimeLib.h in ttn-otaa-network-time example; this is v4.0.1-pre1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1240,6 +1240,9 @@ function uflt12f(rawUflt12)
 
 ## Release History
 
+- HEAD contains the following changes
+  - Adapt ttn-otaa-network-time example to be compatible with [PaulStoffregen/Time](https://github.com/PaulStoffregen/Time) v1.6.1, which deletes `Time.h` in favor of `TimeLib.h` [#763](https://github.com/mcci-catena/arduino-lmic/issues/763). Version is v4.0.1-pre1.
+
 - v4.0 is a major release; changes are significant enough to be "likely breaking". It includes the following changes.
 
   - Fix some broken documentation references [#644](https://github.com/mcci-catena/arduino-lmic/issues/644), [#646](https://github.com/mcci-catena/arduino-lmic/pulls/646), [#673](https://github.com/mcci-catena/arduino-lmic/pulls/673).

--- a/examples/ttn-otaa-network-time/ttn-otaa-network-time.ino
+++ b/examples/ttn-otaa-network-time/ttn-otaa-network-time.ino
@@ -27,10 +27,15 @@
  * DevEUI and AppKey.
  *
  * Do not forget to define the radio type correctly in config.h.
+ * 
+ * You will need to also install the library github.com/PaulStoffregen/Time;
+ * you need a version that has TimeLib.h.
  *
  *******************************************************************************/
 
-#include <Time.h>
+// requires library: github.com/PaulStoffregen/Time
+#include <TimeLib.h>    // can't use <Time.h> starting with v1.6.1
+
 #include <lmic.h>
 #include <hal/hal.h>
 #include <SPI.h>

--- a/src/lmic/lmic.h
+++ b/src/lmic/lmic.h
@@ -106,7 +106,7 @@ extern "C"{
 	((((major)*UINT32_C(1)) << 24) | (((minor)*UINT32_C(1)) << 16) | (((patch)*UINT32_C(1)) << 8) | (((local)*UINT32_C(1)) << 0))
 
 #define	ARDUINO_LMIC_VERSION    \
-    ARDUINO_LMIC_VERSION_CALC(4, 0, 0, 0)  /* 4.0.0 */
+    ARDUINO_LMIC_VERSION_CALC(4, 0, 1, 1)  /* 4.0.1-pre1 */
 
 #define	ARDUINO_LMIC_VERSION_GET_MAJOR(v)	\
 	((((v)*UINT32_C(1)) >> 24u) & 0xFFu)


### PR DESCRIPTION
This change is required for CI to work again, due to change in [Time](https://github.com/PaulStoffregen/Time) library.