### PR TITLE
Some more warning removed

### DIFF
--- a/src/lmic/hal.h
+++ b/src/lmic/hal.h
@@ -173,7 +173,7 @@ void hal_pollPendingIRQs_helper();
 void hal_processPendingIRQs(void);
 
 /// \brief check for any pending interrupts: stub if interrupts are enabled.
-static void inline hal_pollPendingIRQs(void)
+static inline void hal_pollPendingIRQs(void)
 	{
 #if !defined(LMIC_USE_INTERRUPTS)
 	hal_pollPendingIRQs_helper();

--- a/src/lmic/lmic_channelshuffle.c
+++ b/src/lmic/lmic_channelshuffle.c
@@ -108,7 +108,7 @@ int LMIC_findNextChannel(
         memcpy(pShuffleMask, pEnableMask, nEntries * sizeof(*pShuffleMask));
         nSet16 = sidewaysSum16(pShuffleMask, nEntries);
     } else {
-        // don't try to skip the last channel becuase it can't be chosen.
+        // don't try to skip the last channel because it can't be chosen.
         lastChannel = -1;
     }
 

--- a/src/lmic/lmic_channelshuffle.c
+++ b/src/lmic/lmic_channelshuffle.c
@@ -121,7 +121,7 @@ int LMIC_findNextChannel(
     // the last channel bit. Post condition: if we really clered a bit,
     // saveLastChannelVal will be non-zero.
     saveLastChannelVal = 0;
-    if (nSet16 > 16 && lastChannel >= 0 && lastChannel <= nEntries * 16) {
+    if (nSet16 > 16 && lastChannel >= 0 && lastChannel <= (int)(nEntries * 16)) {
         uint16_t const saveLastChannelMask = (1 << (lastChannel & 0xF));
 
         saveLastChannelVal = pShuffleMask[lastChannel >> 4] & saveLastChannelMask;


### PR DESCRIPTION
Some more warnings are removed when compiling for AVR arch and a recent version of arduino IDE (gcc-7.3).