### PR TITLE
Adds an interface to change the SPI port.

### DIFF
--- a/src/hal/hal.h
+++ b/src/hal/hal.h
@@ -13,6 +13,7 @@
 #define _hal_hal_h_
 
 #include "arduino_lmic_hal_configuration.h"
+#include "SPI.h"
 
 // for compatbility reasons, we need to disclose the configuration
 // structure as global type lmic_pinmap.
@@ -28,5 +29,11 @@ const u1_t LMIC_UNUSED_PIN = lmic_pinmap::UNUSED_PIN;
 // Use os_init_ex() if you want not to use a const table, or if
 // you need to define a derived type (so you can override methods).
 extern const lmic_pinmap lmic_pins;
+
+/*
+ * Initializes the HAL with a new SPI interface
+ *   - write the new SPI interface 'spi'
+ */
+void hal_set_spi(HardwareSPI *spi);
 
 #endif // _hal_hal_h_


### PR DESCRIPTION
This PR adds a method for the application programmer to change the default SPI interface used by the HAL layer.
In order not to interfere with existing source code it defaults to SPI (same as the currently hard coded SPI interface) and by using the hal_set_spi() method the programmer can now change the used SPI interface. This must be called before os_init().