### PR TITLE
Initialize dht in ttn-abp-feather-us915-dht22 example

### DIFF
--- a/examples/ttn-abp-feather-us915-dht22/ttn-abp-feather-us915-dht22.ino
+++ b/examples/ttn-abp-feather-us915-dht22/ttn-abp-feather-us915-dht22.ino
@@ -234,6 +234,8 @@ void setup() {
     Serial.begin(115200);
     delay(100);
     Serial.println(F("Starting"));
+    
+    dht.begin();
 
     // LMIC init
     os_init();


### PR DESCRIPTION
DHT initialization is missing in the ttn-abp-feather-us915-dht22 example. Fix it.