### PR TITLE
add include for u1_t type

### DIFF
--- a/src/hal/hal.h
+++ b/src/hal/hal.h
@@ -13,6 +13,7 @@
 #define _hal_hal_h_
 
 #include "arduino_lmic_hal_configuration.h"
+#include "lmic/oslmic_types.h"
 
 // for compatbility reasons, we need to disclose the configuration
 // structure as global type lmic_pinmap.


### PR DESCRIPTION
If the `#include "hal/hal.h"` comes before the `#include "lmic.h"`, the compiler complains that the `u1_t` is not defined. This small change resolves this problem.
