### PR TITLE
Comment the last frequency

### DIFF
--- a/project_config/lmic_project_config.h
+++ b/project_config/lmic_project_config.h
@@ -1,6 +1,6 @@
 // project-specific definitions
 //#define CFG_eu868 1
-#define CFG_us915 1
+//#define CFG_us915 1
 //#define CFG_au915 1
 //#define CFG_as923 1
 // #define LMIC_COUNTRY_CODE LMIC_COUNTRY_CODE_JP      /* for as923-JP; also define CFG_as923 */


### PR DESCRIPTION
The uncommented "default"-Frequency prevents users from defining their wanted frequency, yielding an error caused by multiple defined ranges (config.h Line 25).  Consider selecting "us" as default in config.h line 23