### PR TITLE
Rename `hal_` exports to `lmic_hal_`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ __vm
 
 # files from vscode
 .vscode
+doxygen

--- a/examples/compliance-otaa-halconfig/compliance-otaa-halconfig.ino
+++ b/examples/compliance-otaa-halconfig/compliance-otaa-halconfig.ino
@@ -209,7 +209,7 @@ void LMICOS_logEventUint32(const char *pMessage, uint32_t datum)
     }
 #endif // LMIC_ENABLE_event_logging
 
-hal_failure_handler_t log_assertion;
+lmic_hal_failure_handler_t log_assertion;
 
 void log_assertion(const char *pMessage, uint16_t line) {
     eventQueue.putEvent(ev_t(-3), pMessage, line);
@@ -369,7 +369,7 @@ void printFcnts(cEventQueue::eventnode_t &e) {
 void printAllRegisters(void) {
     uint8_t regbuf[0x80];
     regbuf[0] = 0;
-    hal_spi_read(1, regbuf + 1, sizeof(regbuf) - 1);
+    lmic_hal_spi_read(1, regbuf + 1, sizeof(regbuf) - 1);
 
     for (unsigned i = 0; i < sizeof(regbuf); ++i) {
         if (i % 16 == 0) {
@@ -381,14 +381,14 @@ void printAllRegisters(void) {
     }
 
     // reset the radio, just in case the register dump caused issues.
-    hal_pin_rst(0);
+    lmic_hal_pin_rst(0);
     delay(2);
-    hal_pin_rst(2);
+    lmic_hal_pin_rst(2);
     delay(6);
 
     // restore the radio to idle.
     const uint8_t opmode = 0x88;    // LoRa and sleep.
-    hal_spi_write(0x81, &opmode, 1);
+    lmic_hal_spi_write(0x81, &opmode, 1);
 }
 #endif
 
@@ -698,7 +698,7 @@ void setup() {
     }
 
     // now that we have a pinmap, initalize the low levels accordingly.
-    hal_set_failure_handler(log_assertion);
+    lmic_hal_set_failure_handler(log_assertion);
     os_init_ex(pPinMap);
 
     // LMIC_reset() doesn't affect callbacks, so we can do this first.

--- a/src/arduino_lmic_hal_configuration.h
+++ b/src/arduino_lmic_hal_configuration.h
@@ -114,7 +114,7 @@ public:
 		}
 	};
 
-bool hal_init_with_pinmap(const HalPinmap_t *pPinmap);
+bool lmic_hal_init_with_pinmap(const HalPinmap_t *pPinmap);
 
 }; // end namespace Arduino_LMIC
 

--- a/src/hal/hal.cpp
+++ b/src/hal/hal.cpp
@@ -25,11 +25,11 @@
 static const Arduino_LMIC::HalPinmap_t *plmic_pins;
 static Arduino_LMIC::HalConfiguration_t *pHalConfig;
 static Arduino_LMIC::HalConfiguration_t nullHalConig;
-static hal_failure_handler_t* custom_hal_failure_handler = NULL;
+static lmic_hal_failure_handler_t* custom_hal_failure_handler = NULL;
 
-static void hal_interrupt_init(); // Fwd declaration
+static void lmic_hal_interrupt_init(); // Fwd declaration
 
-static void hal_io_init () {
+static void lmic_hal_io_init () {
     // NSS and DIO0 are required, DIO1 is required for LoRa, DIO2 for FSK
     ASSERT(plmic_pins->nss != LMIC_UNUSED_PIN);
     ASSERT(plmic_pins->dio[0] != LMIC_UNUSED_PIN);
@@ -62,17 +62,17 @@ static void hal_io_init () {
         pinMode(pHalConfig->queryBusyPin(), INPUT);
     }
 
-    hal_interrupt_init();
+    lmic_hal_interrupt_init();
 }
 
 // val == 1  => tx
-void hal_pin_rxtx (u1_t val) {
+void lmic_hal_pin_rxtx (u1_t val) {
     if (plmic_pins->rxtx != LMIC_UNUSED_PIN)
         digitalWrite(plmic_pins->rxtx, val != plmic_pins->rxtx_rx_active);
 }
 
 // set radio RST pin to given value (or keep floating!)
-void hal_pin_rst (u1_t val) {
+void lmic_hal_pin_rst (u1_t val) {
     if (plmic_pins->rst == LMIC_UNUSED_PIN)
         return;
 
@@ -84,7 +84,7 @@ void hal_pin_rst (u1_t val) {
     }
 }
 
-s1_t hal_getRssiCal (void) {
+s1_t lmic_hal_getRssiCal (void) {
     return plmic_pins->rssi_cal;
 }
 
@@ -96,7 +96,7 @@ static_assert(NUM_DIO_INTERRUPT <= NUM_DIO, "Number of interrupt-sensitive lines
 static ostime_t interrupt_time[NUM_DIO_INTERRUPT] = {0};
 
 #if !defined(LMIC_USE_INTERRUPTS)
-static void hal_interrupt_init() {
+static void lmic_hal_interrupt_init() {
     pinMode(plmic_pins->dio[0], INPUT);
     if (plmic_pins->dio[1] != LMIC_UNUSED_PIN)
         pinMode(plmic_pins->dio[1], INPUT);
@@ -106,7 +106,7 @@ static void hal_interrupt_init() {
 }
 
 static bool dio_states[NUM_DIO_INTERRUPT] = {0};
-void hal_pollPendingIRQs_helper() {
+void lmic_hal_pollPendingIRQs_helper() {
     uint8_t i;
     for (i = 0; i < NUM_DIO_INTERRUPT; ++i) {
         if (plmic_pins->dio[i] == LMIC_UNUSED_PIN)
@@ -125,19 +125,19 @@ void hal_pollPendingIRQs_helper() {
 #else
 // Interrupt handlers
 
-static void hal_isrPin0() {
+static void lmic_hal_isrPin0() {
     if (interrupt_time[0] == 0) {
         ostime_t now = os_getTime();
         interrupt_time[0] = now ? now : 1;
     }
 }
-static void hal_isrPin1() {
+static void lmic_hal_isrPin1() {
     if (interrupt_time[1] == 0) {
         ostime_t now = os_getTime();
         interrupt_time[1] = now ? now : 1;
     }
 }
-static void hal_isrPin2() {
+static void lmic_hal_isrPin2() {
     if (interrupt_time[2] == 0) {
         ostime_t now = os_getTime();
         interrupt_time[2] = now ? now : 1;
@@ -145,10 +145,10 @@ static void hal_isrPin2() {
 }
 
 typedef void (*isr_t)();
-static const isr_t interrupt_fns[NUM_DIO_INTERRUPT] = {hal_isrPin0, hal_isrPin1, hal_isrPin2};
+static const isr_t interrupt_fns[NUM_DIO_INTERRUPT] = {lmic_hal_isrPin0, lmic_hal_isrPin1, lmic_hal_isrPin2};
 static_assert(NUM_DIO_INTERRUPT == 3, "number of interrupts must be 3 for initializing interrupt_fns[]");
 
-static void hal_interrupt_init() {
+static void lmic_hal_interrupt_init() {
   for (uint8_t i = 0; i < NUM_DIO_INTERRUPT; ++i) {
       if (plmic_pins->dio[i] == LMIC_UNUSED_PIN)
           continue;
@@ -159,7 +159,7 @@ static void hal_interrupt_init() {
 }
 #endif // LMIC_USE_INTERRUPTS
 
-void hal_processPendingIRQs() {
+void lmic_hal_processPendingIRQs() {
     uint8_t i;
     for (i = 0; i < NUM_DIO_INTERRUPT; ++i) {
         ostime_t iTime;
@@ -187,23 +187,23 @@ void hal_processPendingIRQs() {
 // -----------------------------------------------------------------------------
 // SPI
 
-static void hal_spi_init () {
+static void lmic_hal_spi_init () {
     SPI.begin();
 }
 
 #if (defined(CFG_sx1261_radio) || defined(CFG_sx1262_radio))
-bit_t hal_radio_spi_is_busy() {
+bit_t lmic_hal_radio_spi_is_busy() {
     // SX126x uses BUSY pin
     return digitalRead(pHalConfig->queryBusyPin()) ? true : false;
 }
 #else
 // supply a definition just in case, because the declaration is not conditional
-bit_t hal_radio_spi_is_busy() {
+bit_t lmic_hal_radio_spi_is_busy() {
     return false;
 }
 #endif // (defined(CFG_sx1261_radio) || defined(CFG_sx1262_radio))
 
-static void hal_spi_trx(u1_t cmd, u1_t* buf, size_t len, bit_t is_read) {
+static void lmic_hal_spi_trx(u1_t cmd, u1_t* buf, size_t len, bit_t is_read) {
     uint32_t spi_freq;
     u1_t nss = plmic_pins->nss;
 
@@ -216,7 +216,7 @@ static void hal_spi_trx(u1_t cmd, u1_t* buf, size_t len, bit_t is_read) {
 
     // SX126x modems use BUSY pin. Only interact with SPI when BUSY goes LOW 
 #if (defined(CFG_sx1261_radio) || defined(CFG_sx1262_radio))
-    while (hal_radio_spi_is_busy());
+    while (lmic_hal_radio_spi_is_busy());
 #endif
 
     SPI.transfer(cmd);
@@ -232,17 +232,17 @@ static void hal_spi_trx(u1_t cmd, u1_t* buf, size_t len, bit_t is_read) {
     SPI.endTransaction();
 }
 
-void hal_spi_write(u1_t cmd, const u1_t* buf, size_t len) {
-    hal_spi_trx(cmd, (u1_t*)buf, len, 0);
+void lmic_hal_spi_write(u1_t cmd, const u1_t* buf, size_t len) {
+    lmic_hal_spi_trx(cmd, (u1_t*)buf, len, 0);
 }
 
-void hal_spi_read(u1_t cmd, u1_t* buf, size_t len) {
-    hal_spi_trx(cmd, buf, len, 1);
+void lmic_hal_spi_read(u1_t cmd, u1_t* buf, size_t len) {
+    lmic_hal_spi_trx(cmd, buf, len, 1);
 }
 
 // SX126x modems behave slightly differently to SX127x. They will often need to transfer multiple bytes before reading
 #if (defined(CFG_sx1261_radio) || defined(CFG_sx1262_radio))
-void hal_spi_read_sx126x(u1_t cmd, u1_t* addr, size_t addr_len, u1_t* buf, size_t buf_len) {
+void lmic_hal_spi_read_sx126x(u1_t cmd, u1_t* addr, size_t addr_len, u1_t* buf, size_t buf_len) {
     uint32_t spi_freq;
     u1_t nss = plmic_pins->nss;
 
@@ -253,7 +253,7 @@ void hal_spi_read_sx126x(u1_t cmd, u1_t* addr, size_t addr_len, u1_t* buf, size_
     SPI.beginTransaction(settings);
     digitalWrite(nss, 0);
 
-    while (hal_radio_spi_is_busy());
+    while (lmic_hal_radio_spi_is_busy());
 
     SPI.transfer(cmd);
 
@@ -278,11 +278,11 @@ void hal_spi_read_sx126x(u1_t cmd, u1_t* addr, size_t addr_len, u1_t* buf, size_
 // -----------------------------------------------------------------------------
 // TIME
 
-static void hal_time_init () {
+static void lmic_hal_time_init () {
     // Nothing to do
 }
 
-u4_t hal_ticks () {
+u4_t lmic_hal_ticks () {
     // Because micros() is scaled down in this function, micros() will
     // overflow before the tick timer should, causing the tick timer to
     // miss a significant part of its values if not corrected. To fix
@@ -330,7 +330,7 @@ u4_t hal_ticks () {
 // Returns the number of ticks until time. Negative values indicate that
 // time has already passed.
 static s4_t delta_time(u4_t time) {
-    return (s4_t)(time - hal_ticks());
+    return (s4_t)(time - lmic_hal_ticks());
 }
 
 // deal with boards that are stressed by no-interrupt delays #529, etc.
@@ -342,7 +342,7 @@ static s4_t delta_time(u4_t time) {
 # define HAL_WAITUNTIL_DOWNCOUNT_THRESH ms2osticks(9) // but try to leave a little slack for final timing.
 #endif
 
-u4_t hal_waitUntil (u4_t time) {
+u4_t lmic_hal_waitUntil (u4_t time) {
     s4_t delta = delta_time(time);
     // check for already too late.
     if (delta < 0)
@@ -388,19 +388,19 @@ u4_t hal_waitUntil (u4_t time) {
 }
 
 // check and rewind for target time
-u1_t hal_checkTimer (u4_t time) {
+u1_t lmic_hal_checkTimer (u4_t time) {
     // No need to schedule wakeup, since we're not sleeping
     return delta_time(time) <= 0;
 }
 
 static uint8_t irqlevel = 0;
 
-void hal_disableIRQs () {
+void lmic_hal_disableIRQs () {
     noInterrupts();
     irqlevel++;
 }
 
-void hal_enableIRQs () {
+void lmic_hal_enableIRQs () {
     if(--irqlevel == 0) {
         interrupts();
 
@@ -414,17 +414,17 @@ void hal_enableIRQs () {
         // As an additional bonus, this prevents the can of worms that
         // we would otherwise get for running SPI transfers inside ISRs.
         // We merely collect the edges and timestamps here; we wait for
-        // a call to hal_processPendingIRQs() before dispatching.
-        hal_pollPendingIRQs_helper();
+        // a call to lmic_hal_processPendingIRQs() before dispatching.
+        lmic_hal_pollPendingIRQs_helper();
 #endif /* !defined(LMIC_USE_INTERRUPTS) */
     }
 }
 
-uint8_t hal_getIrqLevel(void) {
+uint8_t lmic_hal_getIrqLevel(void) {
     return irqlevel;
 }
 
-void hal_sleep () {
+void lmic_hal_sleep () {
     // Not implemented
 }
 
@@ -444,7 +444,7 @@ static cookie_io_functions_t functions =
      .close = NULL
  };
 
-void hal_printf_init() {
+void lmic_hal_printf_init() {
     stdout = fopencookie(NULL, "w", functions);
     if (stdout != nullptr) {
         setvbuf(stdout, NULL, _IONBF, 0);
@@ -457,7 +457,7 @@ static int uart_putchar (char c, FILE *)
     return 0 ;
 }
 
-void hal_printf_init() {
+void lmic_hal_printf_init() {
     // create a FILE structure to reference our UART output function
     static FILE uartout;
     memset(&uartout, 0, sizeof(uartout));
@@ -472,23 +472,23 @@ void hal_printf_init() {
 #endif // !defined(ESP8266) || defined(ESP31B) || defined(ESP32)
 #endif // defined(LMIC_PRINTF_TO)
 
-void hal_init (void) {
+void lmic_hal_init (void) {
     // use the global constant
-    Arduino_LMIC::hal_init_with_pinmap(&lmic_pins);
+    Arduino_LMIC::lmic_hal_init_with_pinmap(&lmic_pins);
 }
 
-// hal_init_ex is a C API routine, written in C++, and it's called
+// lmic_hal_init_ex is a C API routine, written in C++, and it's called
 // with a pointer to an lmic_pinmap.
-void hal_init_ex (const void *pContext) {
+void lmic_hal_init_ex (const void *pContext) {
     const lmic_pinmap * const pHalPinmap = (const lmic_pinmap *) pContext;
-    if (! Arduino_LMIC::hal_init_with_pinmap(pHalPinmap)) {
-        hal_failed(__FILE__, __LINE__);
+    if (! Arduino_LMIC::lmic_hal_init_with_pinmap(pHalPinmap)) {
+        lmic_hal_failed(__FILE__, __LINE__);
     }
 }
 
 // C++ API: initialize the HAL properly with a configuration object
 namespace Arduino_LMIC {
-bool hal_init_with_pinmap(const HalPinmap_t *pPinmap)
+bool lmic_hal_init_with_pinmap(const HalPinmap_t *pPinmap)
     {
     if (pPinmap == nullptr)
         return false;
@@ -507,14 +507,14 @@ bool hal_init_with_pinmap(const HalPinmap_t *pPinmap)
     pHalConfig->begin();
 
     // configure radio I/O and interrupt handler
-    hal_io_init();
+    lmic_hal_io_init();
     // configure radio SPI
-    hal_spi_init();
+    lmic_hal_spi_init();
     // configure timer and interrupt handler
-    hal_time_init();
+    lmic_hal_time_init();
 #if defined(LMIC_PRINTF_TO)
     // printf support
-    hal_printf_init();
+    lmic_hal_printf_init();
 #endif
     // declare success
     return true;
@@ -522,7 +522,7 @@ bool hal_init_with_pinmap(const HalPinmap_t *pPinmap)
 }; // namespace Arduino_LMIC
 
 
-void hal_failed (const char *file, u2_t line) {
+void lmic_hal_failed (const char *file, u2_t line) {
     if (custom_hal_failure_handler != NULL) {
         (*custom_hal_failure_handler)(file, line);
     }
@@ -535,7 +535,7 @@ void hal_failed (const char *file, u2_t line) {
     LMIC_FAILURE_TO.flush();
 #endif
 
-    hal_disableIRQs();
+    lmic_hal_disableIRQs();
 
     // Infinite loop
     while (1) {
@@ -543,34 +543,34 @@ void hal_failed (const char *file, u2_t line) {
     }
 }
 
-void hal_set_failure_handler(const hal_failure_handler_t* const handler) {
+void lmic_hal_set_failure_handler(const lmic_hal_failure_handler_t* const handler) {
     custom_hal_failure_handler = handler;
 }
 
-ostime_t hal_setModuleActive (bit_t val) {
+ostime_t lmic_hal_setModuleActive (bit_t val) {
     // setModuleActive() takes a c++ bool, so
     // it effectively says "val != 0". We
     // don't have to.
     return pHalConfig->setModuleActive(val);
 }
 
-bit_t hal_queryUsingTcxo(void) {
+bit_t lmic_hal_queryUsingTcxo(void) {
     return pHalConfig->queryUsingTcxo();
 }
 
-bit_t hal_queryUsingDcdc(void) {
+bit_t lmic_hal_queryUsingDcdc(void) {
     return pHalConfig->queryUsingDcdc();
 }
 
-bit_t hal_queryUsingDIO2AsRfSwitch(void) {
+bit_t lmic_hal_queryUsingDIO2AsRfSwitch(void) {
     return pHalConfig->queryUsingDIO2AsRfSwitch();
 }
 
-bit_t hal_queryUsingDIO3AsTCXOSwitch(void) {
+bit_t lmic_hal_queryUsingDIO3AsTCXOSwitch(void) {
     return pHalConfig->queryUsingDIO3AsTCXOSwitch();
 }
 
-uint8_t hal_getTxPowerPolicy(
+uint8_t lmic_hal_getTxPowerPolicy(
     u1_t inputPolicy,
     s1_t requestedPower,
     u4_t frequency

--- a/src/lmic/hal.h
+++ b/src/lmic/hal.h
@@ -42,45 +42,45 @@ extern "C"{
 #endif
 
 // The type of an optional user-defined failure handler routine
-typedef void LMIC_ABI_STD hal_failure_handler_t(const char* const file, const uint16_t line);
+typedef void LMIC_ABI_STD lmic_hal_failure_handler_t(const char* const file, const uint16_t line);
 
 /*
  * initialize hardware (IO, SPI, TIMER, IRQ).
  * This API is deprecated as it uses the const global lmic_pins,
  * which the platform can't control or change.
  */
-void hal_init (void);
+void lmic_hal_init (void);
 
 /*
  * Initialize hardware, passing in platform-specific context
  * The pointer is to a HalPinmap_t.
  */
-void hal_init_ex (const void *pContext);
+void lmic_hal_init_ex (const void *pContext);
 
 /*
  * drive radio RX/TX pins (0=rx, 1=tx). Actual polarity
  * is determined by the value of HalPinmap_t::rxtx_rx_active.
  */
-void hal_pin_rxtx (u1_t val);
+void lmic_hal_pin_rxtx (u1_t val);
 
 /*
  * control radio RST pin (0=low, 1=high, 2=floating)
  */
-void hal_pin_rst (u1_t val);
+void lmic_hal_pin_rst (u1_t val);
 
 /*
  * Perform SPI write transaction with radio chip
  *   - write the command byte 'cmd'
  *   - write 'len' bytes out of 'buf'
  */
-void hal_spi_write(u1_t cmd, const u1_t* buf, size_t len);
+void lmic_hal_spi_write(u1_t cmd, const u1_t* buf, size_t len);
 
 /*
  * Perform SPI read transaction with radio chip
  *   - write the command byte 'cmd'
  *   - read 'len' bytes into 'buf'
  */
-void hal_spi_read(u1_t cmd, u1_t* buf, size_t len);
+void lmic_hal_spi_read(u1_t cmd, u1_t* buf, size_t len);
 
 /*
  * Perform SPI read transaction with SX126x series radio chip
@@ -90,66 +90,66 @@ void hal_spi_read(u1_t cmd, u1_t* buf, size_t len);
  *   - read 'buf_len' bytes into 'buf'
  */
 #if (defined(CFG_sx1261_radio) || defined(CFG_sx1262_radio))
-void hal_spi_read_sx126x(u1_t cmd, u1_t* addr, size_t addr_len, u1_t* buf, size_t buf_len);
+void lmic_hal_spi_read_sx126x(u1_t cmd, u1_t* addr, size_t addr_len, u1_t* buf, size_t buf_len);
 #endif
 
 /*
  * disable all CPU interrupts.
  *   - might be invoked nested
- *   - will be followed by matching call to hal_enableIRQs()
+ *   - will be followed by matching call to lmic_hal_enableIRQs()
  */
-void hal_disableIRQs (void);
+void lmic_hal_disableIRQs (void);
 
 /*
  * enable CPU interrupts.
  */
-void hal_enableIRQs (void);
+void lmic_hal_enableIRQs (void);
 
 /*
  * return CPU interrupt nesting count
  */
-uint8_t hal_getIrqLevel (void);
+uint8_t lmic_hal_getIrqLevel (void);
 
 /*
  * put system and CPU in low-power mode, sleep until interrupt.
  */
-void hal_sleep (void);
+void lmic_hal_sleep (void);
 
 /*
  * return 32-bit system time in ticks.
  */
-u4_t hal_ticks (void);
+u4_t lmic_hal_ticks (void);
 
 /*
  * busy-wait until specified timestamp (in ticks) is reached. If on-time, return 0,
  * otherwise return the number of ticks we were late.
  */
-u4_t hal_waitUntil (u4_t time);
+u4_t lmic_hal_waitUntil (u4_t time);
 
 /*
  * check and rewind timer for target time.
  *   - return 1 if target time is close
  *   - otherwise rewind timer for target time or full period and return 0
  */
-u1_t hal_checkTimer (u4_t targettime);
+u1_t lmic_hal_checkTimer (u4_t targettime);
 
 /*
  * perform fatal failure action.
  *   - called by assertions
  *   - action could be HALT or reboot
  */
-void hal_failed (const char *file, u2_t line);
+void lmic_hal_failed (const char *file, u2_t line);
 
 /*
  * set a custom hal failure handler routine. The default behaviour, defined in
- * hal_failed(), is to halt by looping infintely.
+ * lmic_hal_failed(), is to halt by looping infintely.
  */
-void hal_set_failure_handler(const hal_failure_handler_t* const);
+void lmic_hal_set_failure_handler(const lmic_hal_failure_handler_t* const);
 
 /*
  * get the calibration value for radio_rssi
  */
-s1_t hal_getRssiCal (void);
+s1_t lmic_hal_getRssiCal (void);
 
 /*
  * control the radio state
@@ -157,19 +157,19 @@ s1_t hal_getRssiCal (void);
  *   - if val == 1, turn tcxo on and otherwise prep for activity
  *   - return the number of ticks that we need to wait
  */
-ostime_t hal_setModuleActive (bit_t val);
+ostime_t lmic_hal_setModuleActive (bit_t val);
 
 /* find out if we're using Tcxo controlled by a host pin */
-bit_t hal_queryUsingTcxo(void);
+bit_t lmic_hal_queryUsingTcxo(void);
 
 /* SX126x function: find out if the board is configured for DC-DC regulator control */
-bit_t hal_queryUsingDcdc(void);
+bit_t lmic_hal_queryUsingDcdc(void);
 
 /* SX126x function: find out if the board is configured to control the RF switch with modem DIO2 */
-bit_t hal_queryUsingDIO2AsRfSwitch(void);
+bit_t lmic_hal_queryUsingDIO2AsRfSwitch(void);
 
 /* SX126x function: find out if the board is configured to control a TCXO with modem DIO3 */
-bit_t hal_queryUsingDIO3AsTCXOSwitch(void);
+bit_t lmic_hal_queryUsingDIO3AsTCXOSwitch(void);
 
 /* represent the various radio TX power policy */
 enum	{
@@ -183,21 +183,21 @@ enum	{
  * to be used on this board, given our desires and
  * requested power.
  */
-uint8_t hal_getTxPowerPolicy(
+uint8_t lmic_hal_getTxPowerPolicy(
 	u1_t inputPolicy,
 	s1_t requestedPower,
 	u4_t freq
 	);
 
-void hal_pollPendingIRQs_helper();
-void hal_processPendingIRQs(void);
-bit_t hal_radio_spi_is_busy();
+void lmic_hal_pollPendingIRQs_helper();
+void lmic_hal_processPendingIRQs(void);
+bit_t lmic_hal_radio_spi_is_busy();
 
 /// \brief check for any pending interrupts: stub if interrupts are enabled.
-static inline void hal_pollPendingIRQs(void)
+static inline void lmic_hal_pollPendingIRQs(void)
 	{
 #if !defined(LMIC_USE_INTERRUPTS)
-	hal_pollPendingIRQs_helper();
+	lmic_hal_pollPendingIRQs_helper();
 #endif /* !defined(LMIC_USE_INTERRUPTS) */
 	}
 

--- a/src/lmic/lmic.h
+++ b/src/lmic/lmic.h
@@ -106,7 +106,7 @@ extern "C"{
 	((((major)*UINT32_C(1)) << 24) | (((minor)*UINT32_C(1)) << 16) | (((patch)*UINT32_C(1)) << 8) | (((local)*UINT32_C(1)) << 0))
 
 #define	ARDUINO_LMIC_VERSION    \
-    ARDUINO_LMIC_VERSION_CALC(4, 2, 0, 3)  /* 4.2.0-pre3 */
+    ARDUINO_LMIC_VERSION_CALC(5, 0, 0, 1)  /* 5.0.0-pre1 */
 
 #define	ARDUINO_LMIC_VERSION_GET_MAJOR(v)	\
 	((((v)*UINT32_C(1)) >> 24u) & 0xFFu)

--- a/src/lmic/oslmic.c
+++ b/src/lmic/oslmic.c
@@ -40,7 +40,7 @@ static struct {
 
 int os_init_ex (const void *pintable) {
     memset(&OS, 0x00, sizeof(OS));
-    hal_init_ex(pintable);
+    lmic_hal_init_ex(pintable);
     if (! radio_init())
         return 0;
     LMIC_init();
@@ -54,7 +54,7 @@ void os_init() {
 }
 
 ostime_t os_getTime () {
-    return hal_ticks();
+    return lmic_hal_ticks();
 }
 
 // unlink job from queue, return if removed
@@ -74,17 +74,17 @@ static osjob_t** getJobQueue(osjob_t* job) {
 
 // clear scheduled job
 void os_clearCallback (osjob_t* job) {
-    hal_disableIRQs();
+    lmic_hal_disableIRQs();
 
     unlinkjob(getJobQueue(job), job);
 
-    hal_enableIRQs();
+    lmic_hal_enableIRQs();
 }
 
 // schedule immediately runnable job
 void os_setCallback (osjob_t* job, osjobcb_t cb) {
     osjob_t** pnext;
-    hal_disableIRQs();
+    lmic_hal_disableIRQs();
 
     // remove if job was already queued
     unlinkjob(getJobQueue(job), job);
@@ -97,7 +97,7 @@ void os_setCallback (osjob_t* job, osjobcb_t cb) {
     // add to end of run queue
     for(pnext=&OS.runnablejobs; *pnext; pnext=&((*pnext)->next));
     *pnext = job;
-    hal_enableIRQs();
+    lmic_hal_enableIRQs();
 }
 
 // schedule timed job
@@ -108,7 +108,7 @@ void os_setTimedCallback (osjob_t* job, ostime_t time, osjobcb_t cb) {
     if (time == 0)
         time = 1;
 
-    hal_disableIRQs();
+    lmic_hal_disableIRQs();
 
     // remove if job was already queued
     unlinkjob(getJobQueue(job), job);
@@ -127,7 +127,7 @@ void os_setTimedCallback (osjob_t* job, ostime_t time, osjobcb_t cb) {
         }
     }
     *pnext = job;
-    hal_enableIRQs();
+    lmic_hal_enableIRQs();
 }
 
 // execute jobs from timer and from run queue
@@ -139,20 +139,20 @@ void os_runloop () {
 
 void os_runloop_once() {
     osjob_t* j = NULL;
-    hal_processPendingIRQs();
+    lmic_hal_processPendingIRQs();
 
-    hal_disableIRQs();
+    lmic_hal_disableIRQs();
     // check for runnable jobs
     if(OS.runnablejobs) {
         j = OS.runnablejobs;
         OS.runnablejobs = j->next;
-    } else if(OS.scheduledjobs && hal_checkTimer(OS.scheduledjobs->deadline)) { // check for expired timed jobs
+    } else if(OS.scheduledjobs && lmic_hal_checkTimer(OS.scheduledjobs->deadline)) { // check for expired timed jobs
         j = OS.scheduledjobs;
         OS.scheduledjobs = j->next;
     } else { // nothing pending
-        hal_sleep(); // wake by irq (timer already restarted)
+        lmic_hal_sleep(); // wake by irq (timer already restarted)
     }
-    hal_enableIRQs();
+    lmic_hal_enableIRQs();
     if(j) { // run job callback
         j->func(j);
     }

--- a/src/lmic/oslmic.h
+++ b/src/lmic/oslmic.h
@@ -52,7 +52,7 @@ LMIC_BEGIN_DECLS
 #define EV(a,b,c) /**/
 #define DO_DEVDB(field1,field2) /**/
 #if !defined(CFG_noassert)
-#define ASSERT(cond) if(!(cond)) hal_failed(__FILE__, __LINE__)
+#define ASSERT(cond) if(!(cond)) lmic_hal_failed(__FILE__, __LINE__)
 #else
 #define ASSERT(cond) /**/
 #endif

--- a/src/lmic/radio_sx126x.c
+++ b/src/lmic/radio_sx126x.c
@@ -259,7 +259,7 @@ static void writeRegister(u2_t addr, u1_t data) {
         data,
     };
 
-    hal_spi_write(WriteRegister, addr_buf, SX126X_RW_REGISTER_LEN);
+    lmic_hal_spi_write(WriteRegister, addr_buf, SX126X_RW_REGISTER_LEN);
 }
 
 // Return one byte from register `addr`
@@ -270,7 +270,7 @@ static u1_t readRegister(u2_t addr) {
         SX126X_NOP,
     };
     u1_t buf;
-    hal_spi_read_sx126x(ReadRegister, addr_buf, SX126X_RW_REGISTER_LEN, &buf, 1);
+    lmic_hal_spi_read_sx126x(ReadRegister, addr_buf, SX126X_RW_REGISTER_LEN, &buf, 1);
     return buf;
 }
 
@@ -278,7 +278,7 @@ static u1_t readRegister(u2_t addr) {
 static void writeBuffer(u1_t addr, xref2u1_t buf, u1_t len) {
     // Set the TX buffer base address. Leave RX base address as 0
     u1_t baseAddr[SX126X_BUFF_BASE_ADDR_LEN] = {addr, 0};
-    hal_spi_write(SetBufferBaseAddress, &addr, SX126X_BUFF_BASE_ADDR_LEN);
+    lmic_hal_spi_write(SetBufferBaseAddress, &addr, SX126X_BUFF_BASE_ADDR_LEN);
 
     // Prepend the offset byte to the data being written to the buffer
     u1_t new_buf[len + 1];
@@ -287,7 +287,7 @@ static void writeBuffer(u1_t addr, xref2u1_t buf, u1_t len) {
         new_buf[i] = buf[i - 1];
     }
 
-    hal_spi_write(WriteBuffer, new_buf, len + 1);
+    lmic_hal_spi_write(WriteBuffer, new_buf, len + 1);
 }
 
 // Read `len` bytes from the FIFO buffer to `buf` from position `offset`
@@ -297,7 +297,7 @@ static void readBuffer(u1_t offset, xref2u1_t buf, u1_t len) {
         SX126X_NOP,
     };
 
-    hal_spi_read_sx126x(ReadBuffer, offset_buf, SX126X_W_BUFFER_LEN, buf, len);
+    lmic_hal_spi_read_sx126x(ReadBuffer, offset_buf, SX126X_W_BUFFER_LEN, buf, len);
 }
 
 // Chapter 13.1: Operational Modes Functions
@@ -308,26 +308,26 @@ static void readBuffer(u1_t offset, xref2u1_t buf, u1_t len) {
 static void setSleep(u1_t sleepConfig) {
     // MISSING FUNCTIONALITY sleepConfig can be modified to allow warm start and set an RTC timeout
     // default coldstart sleepConfig = 0x00;
-    hal_spi_write(SetSleep, &sleepConfig, SX126X_SLEEPCONFIG_LEN);
+    lmic_hal_spi_write(SetSleep, &sleepConfig, SX126X_SLEEPCONFIG_LEN);
 }
 
 // Accepts StdbyConfig STDBY_RC or STDBY_XOSC
 static void setStandby(u1_t stdbyConfig) {
-    hal_spi_write(SetStandby, &stdbyConfig, SX126X_STDBYCONFIG_LEN);
+    lmic_hal_spi_write(SetStandby, &stdbyConfig, SX126X_STDBYCONFIG_LEN);
 }
 
 static void setFs(void) {
-    hal_spi_write(SetFs, NULL, 0);
+    lmic_hal_spi_write(SetFs, NULL, 0);
 }
 
 // TODO handle the bit bashing as a macro to allow functions to be called with ms rather than 3 bytes
 static void setTx(u1_t timeout[SX126X_TIMEOUT_LEN]) {
-    hal_spi_write(SetTx, timeout, SX126X_TIMEOUT_LEN);
+    lmic_hal_spi_write(SetTx, timeout, SX126X_TIMEOUT_LEN);
 }
 
 // TODO handle the bit bashing as a macro to allow functions to be called with ms rather than 3 bytes
 static void setRx(u1_t timeout[SX126X_TIMEOUT_LEN]) {
-    hal_spi_write(SetRx, timeout, SX126X_TIMEOUT_LEN);
+    lmic_hal_spi_write(SetRx, timeout, SX126X_TIMEOUT_LEN);
 
     // Workaround 15.3 - Implicit Header Mode Timeout Behaviour
     // It is advised to add the following commands after ANY Rx with Timeout active sequence,
@@ -349,12 +349,12 @@ static void setRx(u1_t timeout[SX126X_TIMEOUT_LEN]) {
 // Default is LDO. DC-DC can be activated by setting regModeParam to 0x01
 // NOTE: This is hardware specific and will need to be described in the pinmap files
 static void setRegulatorMode(u1_t regModeParam) {
-    hal_spi_write(SetRegulatorMode, &regModeParam, SX126X_REGMODEPARAM_LEN);
+    lmic_hal_spi_write(SetRegulatorMode, &regModeParam, SX126X_REGMODEPARAM_LEN);
 }
 
 // 0x7F calibrates all. It's possible to use other bits to calibrate fewer blocks and expedite the cal but for first pass, setting as a default for ease of implementation
 static void calibrate(u1_t calibParam) {
-    hal_spi_write(Calibrate, &calibParam, SX126X_CALIBPARAM_LEN);
+    lmic_hal_spi_write(Calibrate, &calibParam, SX126X_CALIBPARAM_LEN);
 }
 
 static void calibrateImage(void) {
@@ -379,7 +379,7 @@ static void calibrateImage(void) {
         calFreq[1] = 0x6F;
     }
 
-    hal_spi_write(CalibrateImage, calFreq, SX126X_IMAGECALPARAM_LEN);
+    lmic_hal_spi_write(CalibrateImage, calFreq, SX126X_IMAGECALPARAM_LEN);
 }
 
 static void setPaConfig(u1_t paDutyCycle, u1_t hpMax, u1_t deviceSel, u1_t paLut) {
@@ -390,7 +390,7 @@ static void setPaConfig(u1_t paDutyCycle, u1_t hpMax, u1_t deviceSel, u1_t paLut
         paLut,
     };
 
-    hal_spi_write(SetPaConfig, paConfigParam, SX126X_PACONFIGPARAM_LEN);
+    lmic_hal_spi_write(SetPaConfig, paConfigParam, SX126X_PACONFIGPARAM_LEN);
 }
 
 // Chapter 13.3: DIO and IRQ Control Functions
@@ -406,13 +406,13 @@ static void setDioIrqParams(u2_t irqMask, u2_t dio1Mask, u2_t dio2Mask, u2_t dio
         dio3Mask & 0xFF,
     };
 
-    hal_spi_write(SetDioIrqParams, irqParams, SX126X_SETIRQPARAMS_LEN);
+    lmic_hal_spi_write(SetDioIrqParams, irqParams, SX126X_SETIRQPARAMS_LEN);
 }
 
 static u2_t getIrqStatus(void) {
     u1_t nop = SX126X_NOP;
     u1_t buf[SX126X_IRQSTATUS_LEN];
-    hal_spi_read_sx126x(GetIrqStatus, &nop, 1, buf, SX126X_IRQSTATUS_LEN);
+    lmic_hal_spi_read_sx126x(GetIrqStatus, &nop, 1, buf, SX126X_IRQSTATUS_LEN);
     u2_t irqStatus = (buf[0] << 8) | buf[1];
     return irqStatus;
 }
@@ -422,13 +422,13 @@ static void clearIrqStatus(u2_t clearIrqArg) {
         (u1_t)(clearIrqArg >> 8),
         (u1_t)(clearIrqArg & 0xff),
     };
-    hal_spi_write(ClearIrqStatus, clearIrqParams, SX126X_CLEARIRQPARAMS_LEN);
+    lmic_hal_spi_write(ClearIrqStatus, clearIrqParams, SX126X_CLEARIRQPARAMS_LEN);
 }
 
 // Allows direct control of RFswitch by SX126x if the hardware supports it
 static void setDio2AsRfSwitchCtrl(void) {
     u1_t enable = 0x01;
-    hal_spi_write(SetDIO2AsRfSwitchCtrl, &enable, 1);
+    lmic_hal_spi_write(SetDIO2AsRfSwitchCtrl, &enable, 1);
 }
 
 // Allows direct control of TCXO by SX126x if the hardware supports it
@@ -471,7 +471,7 @@ static void setDIO3AsTcxoCtrl(float tcxoVoltage, u1_t delay[SX126X_TIMEOUT_LEN])
         setDio3AsTcxoParam[i] = (i == 0) ? voltageParam : delay[i - 1];
     }
 
-    hal_spi_write(SetDIO3AsTcxoCtrl, setDio3AsTcxoParam, (SX126X_TIMEOUT_LEN + 1));
+    lmic_hal_spi_write(SetDIO3AsTcxoCtrl, setDio3AsTcxoParam, (SX126X_TIMEOUT_LEN + 1));
 }
 
 // Chapter 13.4: RF Modulation and Packet-Related Functions
@@ -486,17 +486,17 @@ static void setRfFrequency(void) {
         (u1_t)(rfFreq >> 0),
     };
 
-    hal_spi_write(SetRfFrequency, rfFreqParam, SX126X_RFFREQPARAMS_LEN);
+    lmic_hal_spi_write(SetRfFrequency, rfFreqParam, SX126X_RFFREQPARAMS_LEN);
 }
 
 static void setPacketType(u1_t packetType) {
-    hal_spi_write(SetPacketType, &packetType, 1);
+    lmic_hal_spi_write(SetPacketType, &packetType, 1);
 }
 
 static u1_t getPacketType(void) {
     u1_t nop = SX126X_NOP;
     u1_t buf;
-    hal_spi_read_sx126x(GetPacketType, &nop, 1, &buf, 1);
+    lmic_hal_spi_read_sx126x(GetPacketType, &nop, 1, &buf, 1);
     return(buf);
 }
 
@@ -544,7 +544,7 @@ static void setTxParams(void) {
         SET_RAMP_40U,
     };
     
-    hal_spi_write(SetTxParams, txParams, 2);
+    lmic_hal_spi_write(SetTxParams, txParams, 2);
 
     // TODO adjust OCP based on tx power to save power
     // Eg SX1262 < 14, set ma to 80. (20 > pa >= 14), set ma to 100. >= 20 then leave at 140ma default that occurs after PAconfig
@@ -594,7 +594,7 @@ static void setModulationParams(u1_t packetType) {
             modParams[3] = 0x01;
         }
 
-        hal_spi_write(SetModulationParams, modParams, SX126X_LORA_MODPARAMS_LEN);
+        lmic_hal_spi_write(SetModulationParams, modParams, SX126X_LORA_MODPARAMS_LEN);
 
     } else {
         // GFSK portion NOT TESTED yet.
@@ -622,7 +622,7 @@ static void setModulationParams(u1_t packetType) {
         modParams[6] = 0x66;
         modParams[7] = 0x66;
 
-        hal_spi_write(SetModulationParams, modParams, SX126X_GFSK_MODPARAMS_LEN);
+        lmic_hal_spi_write(SetModulationParams, modParams, SX126X_GFSK_MODPARAMS_LEN);
     }
 }
 
@@ -647,7 +647,7 @@ static void setPacketParams(u1_t packetType, u1_t frameLength, u1_t invertIQ) {
         packetParams[4] = getNocrc(LMIC.rps) ? 0x00 : 0x01;
         packetParams[5] = invertIQ ? 0x01 : 0x00;
 
-        hal_spi_write(SetPacketParams, packetParams, SX126X_LORA_PACKETPARAMS_LEN);
+        lmic_hal_spi_write(SetPacketParams, packetParams, SX126X_LORA_PACKETPARAMS_LEN);
 
         // Workaround 15.4 - Optimising the Inverted IQ Operation
         if (invertIQ) {
@@ -701,7 +701,7 @@ static void setPacketParams(u1_t packetType, u1_t frameLength, u1_t invertIQ) {
         // GFSK PacketParam9 - WhiteningEnable
         packetParams[8] = 0x01;
 
-        hal_spi_write(SetPacketParams, packetParams, SX126X_LORA_PACKETPARAMS_LEN);
+        lmic_hal_spi_write(SetPacketParams, packetParams, SX126X_LORA_PACKETPARAMS_LEN);
 
         // Sync word is directly programmed into the device through simple register access.
         writeRegister(SyncWord0, 0xC1);
@@ -722,12 +722,12 @@ static void setBufferBaseAddress(void) {
         0x00, // TX base address
         0x00 // RX base address
     };
-    hal_spi_write(SetBufferBaseAddress, buf, 2);
+    lmic_hal_spi_write(SetBufferBaseAddress, buf, 2);
 }
 
 static void setLoRaSymbNumTimeout(void) {
     u1_t buf = {(u1_t)LMIC.rxsyms};
-    hal_spi_write(SetLoRaSymbNumTimeout, &buf, 1);
+    lmic_hal_spi_write(SetLoRaSymbNumTimeout, &buf, 1);
 }
 
 // Chapter 13.5: Communication Status Information
@@ -735,30 +735,30 @@ static void setLoRaSymbNumTimeout(void) {
 // Chip mode is (getStatus | 0x70)
 static u1_t getStatus(void) {
     u1_t status;
-    hal_spi_read_sx126x(GetStatus, NULL, 0, &status, 1);
+    lmic_hal_spi_read_sx126x(GetStatus, NULL, 0, &status, 1);
     return status;
 }
 
 static void getDeviceErrors(xref2cu1_t errorBuf) {
     u1_t nop = SX126X_NOP;
     u1_t errors[2];
-    hal_spi_read_sx126x(GetDeviceErrors, &nop, 1, errors, 2);
+    lmic_hal_spi_read_sx126x(GetDeviceErrors, &nop, 1, errors, 2);
 }
 
 static void clearDeviceErrors(void) {
     u1_t buf[2] = {0};
-    hal_spi_write(ClearDeviceErrors, buf, 2);
+    lmic_hal_spi_write(ClearDeviceErrors, buf, 2);
 }
 
 static void getRxBufferStatus(xref2u1_t rxBufferStatus) {
     u1_t nop = SX126X_NOP;
-    hal_spi_read_sx126x(GetRxBufferStatus, &nop, 1, rxBufferStatus, SX126X_RXBUFFERSTATUS_LEN);
+    lmic_hal_spi_read_sx126x(GetRxBufferStatus, &nop, 1, rxBufferStatus, SX126X_RXBUFFERSTATUS_LEN);
 }
 
 static void getPacketStatus(xref2u1_t rxBufferStatus) {
     u1_t nop = SX126X_NOP;
     u1_t buf[SX126X_PACKETSTATUS_LEN];
-    hal_spi_read_sx126x(GetPacketStatus, &nop, 1, buf, SX126X_PACKETSTATUS_LEN);
+    lmic_hal_spi_read_sx126x(GetPacketStatus, &nop, 1, buf, SX126X_PACKETSTATUS_LEN);
 }
 
 // Perform radio configuration commands required at the start of tx and rx
@@ -766,12 +766,12 @@ void radio_config(void) {
     // Perform necessary operations from STDBY_RC mode 
     if ((getStatus() | SX126x_GETSTATUS_CHIPMODE_MASK) != SX126x_CHIPMODE_STDBY_RC) {
         // Assume we've woken from sleep
-        while (hal_radio_spi_is_busy());
+        while (lmic_hal_radio_spi_is_busy());
         setStandby(STDBY_RC);
     }
 
     // If the board has RfSwitch, switch on
-    if (hal_queryUsingDIO2AsRfSwitch) {
+    if (lmic_hal_queryUsingDIO2AsRfSwitch) {
         setDio2AsRfSwitchCtrl();
     }
 
@@ -780,12 +780,12 @@ void radio_config(void) {
     writeRegister(TxClampConfig, (readRegister(TxClampConfig) | 0x1E));
 
     // DC-DC regulator is hardware dependent
-    if (hal_queryUsingDcdc()) {
+    if (lmic_hal_queryUsingDcdc()) {
         setRegulatorMode(0x01);
     }
 
     // If the board has TCXO, the calibration order is important.
-    if (hal_queryUsingDIO3AsTCXOSwitch()) {
+    if (lmic_hal_queryUsingDIO3AsTCXOSwitch()) {
         float tcxoVoltage = 1.8;
         u1_t tcxoTimeout[SX126X_TIMEOUT_LEN] = {0x00, 0x01, 0x40}; // 
         setDIO3AsTcxoCtrl(tcxoVoltage, tcxoTimeout);
@@ -809,7 +809,7 @@ static void txlora(void) {
 
     writeBuffer(0x00, LMIC.frame, LMIC.dataLen);
 
-    hal_pin_rxtx(1);
+    lmic_hal_pin_rxtx(1);
 
     setModulationParams(PACKET_TYPE_LORA);
     setPacketParams(PACKET_TYPE_LORA, LMIC.dataLen, LMIC.noRXIQinversion);
@@ -827,7 +827,7 @@ static void txlora(void) {
 
     // Start the transmission
     if (LMIC.txend) {
-        u4_t nLate = hal_waitUntil(LMIC.txend); // busy wait until exact tx time
+        u4_t nLate = lmic_hal_waitUntil(LMIC.txend); // busy wait until exact tx time
         if (nLate) {
             LMIC.radio.txlate_ticks += nLate;
             ++LMIC.radio.txlate_count;
@@ -861,7 +861,7 @@ static void txfsk(void) {
 
     writeBuffer(0x00, LMIC.frame, LMIC.dataLen);
 
-    hal_pin_rxtx(1);
+    lmic_hal_pin_rxtx(1);
 
     setModulationParams(PACKET_TYPE_GFSK);
     setPacketParams(PACKET_TYPE_GFSK, LMIC.dataLen, LMIC.noRXIQinversion);
@@ -875,7 +875,7 @@ static void txfsk(void) {
 
     // now we actually start the transmission
     if (LMIC.txend) {
-        u4_t nLate = hal_waitUntil(LMIC.txend); // busy wait until exact tx time
+        u4_t nLate = lmic_hal_waitUntil(LMIC.txend); // busy wait until exact tx time
         if (nLate > 0) {
             LMIC.radio.txlate_ticks += nLate;
             ++LMIC.radio.txlate_count;
@@ -962,7 +962,7 @@ static void rxlora(u1_t rxmode) {
     // Rx Boosted gain. Default is Rx Power saving. Uncomment if boosted is desired
     // writeRegister(RxGain, (readRegister(RxGain) | 0x96));
 
-    hal_pin_rxtx(0);
+    lmic_hal_pin_rxtx(0);
     
     // Set DioIrq params to DIO1
     u2_t dioMask = RxDone | Timeout;
@@ -978,7 +978,7 @@ static void rxlora(u1_t rxmode) {
 
     // now instruct the radio to receive
     if (rxmode == RXMODE_SINGLE) {
-        u4_t nLate = hal_waitUntil(LMIC.rxtime);
+        u4_t nLate = lmic_hal_waitUntil(LMIC.rxtime);
         u1_t rxTimeoutSingle[SX126X_TIMEOUT_LEN] = {
             0x00,
             0x00,
@@ -1038,7 +1038,7 @@ static void rxfsk(u1_t rxmode) {
     // Rx Boosted gain. Default is Rx Power saving. Uncomment if boosted is desired
     // writeRegister(RxGain, (readRegister(RxGain) | 0x96));
 
-    hal_pin_rxtx(0);
+    lmic_hal_pin_rxtx(0);
     
     // Set DioIrq params to DIO1
     u2_t dioMask = RxDone | Timeout;
@@ -1049,7 +1049,7 @@ static void rxfsk(u1_t rxmode) {
 
     // now instruct the radio to receive
     if (rxmode == RXMODE_SINGLE) {
-        u4_t nLate = hal_waitUntil(LMIC.rxtime); // busy wait until exact rx time
+        u4_t nLate = lmic_hal_waitUntil(LMIC.rxtime); // busy wait until exact rx time
         u1_t rxTimeoutSingle[SX126X_TIMEOUT_LEN] = {
             0x00,
             0x00,
@@ -1096,7 +1096,7 @@ void randomNumber(xref2u1_t randbuf) {
 
     setRx(rxTimeoutContinuous);
     
-    hal_waitUntil(os_getTime() + ms2osticks(100)); // TODO 100ms seems excessive so test and reduce
+    lmic_hal_waitUntil(os_getTime() + ms2osticks(100)); // TODO 100ms seems excessive so test and reduce
 
     // Fill each byte with one of the RandomNumberGen registers
     for (u1_t i = 0; i < SX126X_RAND_SEED_LEN / 4; i++) {
@@ -1111,10 +1111,10 @@ void randomNumber(xref2u1_t randbuf) {
 
 // requestModuleActive manages a tcxo controlled by the MCU
 static void requestModuleActive(bit_t state) {
-    ostime_t const ticks = hal_setModuleActive(state);
+    ostime_t const ticks = lmic_hal_setModuleActive(state);
 
     if (ticks) {
-        hal_waitUntil(os_getTime() + ticks);
+        lmic_hal_waitUntil(os_getTime() + ticks);
     }
 }
 
@@ -1130,22 +1130,22 @@ static void requestModuleActive(bit_t state) {
 //! \pre
 //! Preconditions must be observed, or you'll get hangs during initialization.
 //!
-//! - The `hal_pin_..()` functions must be ready for use.
-//! - The `hal_waitUntl()` function must be ready for use. This may mean that interrupts
+//! - The `lmic_hal_pin_..()` functions must be ready for use.
+//! - The `lmic_hal_waitUntl()` function must be ready for use. This may mean that interrupts
 //!   are enabled.
-//! - The `hal_spi_..()` functions must be ready for use.
+//! - The `lmic_hal_spi_..()` functions must be ready for use.
 //!
-//! Generally, all these are satisfied by a call to `hal_init_with_pinmap()`.
+//! Generally, all these are satisfied by a call to `lmic_hal_init_with_pinmap()`.
 //!
 int radio_init(void) {
     requestModuleActive(1);
 
     // manually reset radio
-    hal_pin_rst(0); // drive RST pin low
-    hal_waitUntil(os_getTime()+ms2osticks(1)); // wait >100us
-    hal_pin_rst(2); // configure RST pin floating!
-    hal_waitUntil(os_getTime()+ms2osticks(5)); // wait 5ms
-    while(hal_radio_spi_is_busy()); // wait for busy pin to go low
+    lmic_hal_pin_rst(0); // drive RST pin low
+    lmic_hal_waitUntil(os_getTime()+ms2osticks(1)); // wait >100us
+    lmic_hal_pin_rst(2); // configure RST pin floating!
+    lmic_hal_waitUntil(os_getTime()+ms2osticks(5)); // wait 5ms
+    while(lmic_hal_radio_spi_is_busy()); // wait for busy pin to go low
 
     // Check default LoRa sync word to verify the reset was successful
     u1_t syncWordMSB = readRegister(LoRaSyncWordMSB);
@@ -1183,7 +1183,7 @@ u1_t radio_rand1(void) {
 u1_t radio_rssi(void) {
     u1_t buf;
     u1_t nop = SX126X_NOP;
-    hal_spi_read_sx126x(GetRssiInst, &nop, 1, &buf, 1);
+    lmic_hal_spi_read_sx126x(GetRssiInst, &nop, 1, &buf, 1);
 
     // Problem: Original SX127x returns raw contents of register, but:
     // For SX1276, RSSI = (freq < 525MHz) ? -157 + buf : -164 + buf
@@ -1228,7 +1228,7 @@ void radio_monitor_rssi(ostime_t nTicks, oslmic_radio_rssi_t *pRssi) {
     rssiN = 0;
 
     // wait for PLLs
-    hal_waitUntil(os_getTime() + us2osticks(500));
+    lmic_hal_waitUntil(os_getTime() + us2osticks(500));
 
     // scan for the desired time.
     tBegin = os_getTime();
@@ -1242,7 +1242,7 @@ void radio_monitor_rssi(ostime_t nTicks, oslmic_radio_rssi_t *pRssi) {
 
         u1_t nop = SX126X_NOP;
         u1_t rssiNow;
-        hal_spi_read_sx126x(GetRssiInst, &nop, 1, &rssiNow, 1);
+        lmic_hal_spi_read_sx126x(GetRssiInst, &nop, 1, &rssiNow, 1);
         if (rssiMax < rssiNow)
                 rssiMax = rssiNow;
         if (rssiNow < rssiMin)


### PR DESCRIPTION
This is required for esp32 BSP starting with version 2.

It is a breaking change, so version advances to v5.0.0-pre1.
