### PR TITLE
Fix #967: Add DISABLE_LMIC_FAILURE_TO on AVR test compiles to save space

### DIFF
--- a/ci/lmic-filter-common.sh
+++ b/ci/lmic-filter-common.sh
@@ -68,7 +68,7 @@ function _lmic_filter {
 		_debug _lmic_filter: LMIC_FILTER_SKETCH="$LMIC_FILTER_SKETCH"
 		shift
 		if [[ "$MCCI_CI_ARCH" = "avr" ]]; then
-			_projcfg_class_a "$@"
+			_projcfg_class_a "$@"  "DISABLE_LMIC_FAILURE_TO"
 		else
 			_projcfg "$@"
 		fi


### PR DESCRIPTION
This allows all the regression tests to build, including avr. Fix #967.