### PR TITLE
Fix hang after 8 hours with certain compilers

### DIFF
--- a/README.md
+++ b/README.md
@@ -999,6 +999,10 @@ function uflt12f(rawUflt12)
 
 ## Release History
 
+- HEAD has the following changes.
+
+  - Work around different behavior for `int32_t` wrap in newer GCC versions. ([#968](https://github.com/mcci-catena/arduino-lmic/issues/968), `v5.0.1-pre1`)
+
 - v5.0.0 has the following changes.
 
   - Enable device time request by default in config file ([#840](https://github.com/mcci-catena/arduino-lmic/issues/840)).

--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -2608,7 +2608,7 @@ static void engineUpdate_inner (void) {
         // otherwise the compiler falsely assumes that the computation
         // is positive.
         //
-        if( ((ostime_t) (txbeg - (now + TX_RAMPUP)) < 0 ) {
+        if( ((ostime_t) (txbeg - (now + TX_RAMPUP))) < 0 ) {
             // We could send right now!
             txbeg = now;
             dr_t txdr = (dr_t)LMIC.datarate;

--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -2608,7 +2608,8 @@ static void engineUpdate_inner (void) {
         // otherwise the compiler falsely assumes that the computation
         // is positive.
         //
-        if( ((ostime_t) (txbeg - (now + TX_RAMPUP))) < 0 ) {
+        volatile ostime_t tdiff = txbeg - (now + TX_RAMPUP);
+        if( tdiff < 0 ) {
             // We could send right now!
             txbeg = now;
             dr_t txdr = (dr_t)LMIC.datarate;

--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -2597,8 +2597,18 @@ static void engineUpdate_inner (void) {
             goto checkrx;
         }
 #endif // !DISABLE_BEACONS
-        // Earliest possible time vs overhead to setup radio
-        if( txbeg - (now + TX_RAMPUP) < 0 ) {
+
+        //
+        // Compare earliest possible time vs overhead to setup radio, and start
+        // transmit if we can. Otherwise (way below), if we're not tracking a
+        // beacon, we'll simply queue an osjob for the computed txbeg time.
+        //
+        // Per bug #968, the explicit cast to (ostime_t) is needed
+        // (with some versions of GCC) if txbeg is positive and now + TX_RAMPUP is negative
+        // otherwise the compiler falsely assumes that the computation
+        // is positive.
+        //
+        if( ((ostime_t) (txbeg - (now + TX_RAMPUP)) < 0 ) {
             // We could send right now!
             txbeg = now;
             dr_t txdr = (dr_t)LMIC.datarate;

--- a/src/lmic/lmic.h
+++ b/src/lmic/lmic.h
@@ -106,7 +106,7 @@ extern "C"{
 	((((major)*UINT32_C(1)) << 24) | (((minor)*UINT32_C(1)) << 16) | (((patch)*UINT32_C(1)) << 8) | (((local)*UINT32_C(1)) << 0))
 
 #define	ARDUINO_LMIC_VERSION    \
-    ARDUINO_LMIC_VERSION_CALC(5, 0, 0, 0)  /* 5.0.0 */
+    ARDUINO_LMIC_VERSION_CALC(5, 0, 1, 1)  /* 5.0.1-pre1 */
 
 #define	ARDUINO_LMIC_VERSION_GET_MAJOR(v)	\
 	((((v)*UINT32_C(1)) >> 24u) & 0xFFu)


### PR DESCRIPTION
Per issue #968, some recent compilers get confused by the integer comparison `if ( (txbeg - (now + TX_RAMPUP)) < 0)` comparison which appears in `engine_update_inner()`.  Apparently, the macro expansion for `TX_RAMPUP` (which involves a call to `us2osticks()`, which is again a macro) causes the expression to be promoted to `int64_t` despite the explicit type casts on the result.

Not surprisingly, adding more typecasts doesn't help. What helps is computing `txbeg - (now + TX_RAMPUP)) `, assigning the result to a `volatile osticks_t` variable, and then checking that.  `volatile` forces the assignment to actually take effect, and `osticks_t` is the 32-bit integral type we want.