### PR TITLE
Add SX1276 version 0x13 for S76G

### DIFF
--- a/src/lmic/radio_sx127x.c
+++ b/src/lmic/radio_sx127x.c
@@ -1109,7 +1109,7 @@ int radio_init () {
     // some sanity checks, e.g., read version number
     u1_t v = readReg(RegVersion);
 #ifdef CFG_sx1276_radio
-    if(v != 0x12 )
+    if(v != 0x12 && v != 0x13)
         return 0;
 #elif CFG_sx1272_radio
     if(v != 0x22)


### PR DESCRIPTION
The SX1276 in my LilyGO T-Motion seems to be version `0x13` and this seems to be the case for all S76G packaged chips. Currently the library checks for version `0x12`, and fails.

This also seems to be LilyGO's advice for the T-Impulse: https://github.com/Xinyuan-LilyGO/T-Impulse#notice

I'm not sure if there are any differences other than being packaged in an S76G, but it works fine for me!

Thanks,
Steve
