### PR TITLE
Skip compliance-otaa-halconfig on AVR CI (fixes #1022)

### DIFF
--- a/ci/lmic-filter-common.sh
+++ b/ci/lmic-filter-common.sh
@@ -47,6 +47,10 @@ function _lmic_filter {
 			"stm32:ttn-otaa-feather-us915.ino")
 				return 1
 				;;
+			# compliance-otaa-halconfig exceeds flash on AVR (feather32u4)
+			"avr:compliance-otaa-halconfig.ino")
+				return 1
+				;;
 			*)
 				return 0
 				;;


### PR DESCRIPTION
## Summary

- Skip `compliance-otaa-halconfig.ino` on AVR in CI -- it exceeds flash capacity on feather32u4
- Follows existing pattern in `ci/lmic-filter-common.sh` for architecture-specific sketch filtering
- Sketch still builds on samd, stm32, esp32

Fixes #1022

🤖 Generated with [Claude Code](https://claude.com/claude-code)