### PR TITLE
Fix ABP broken by missing SE key propagation in v6.0.0

### DIFF
--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -282,7 +282,7 @@ static void rxschedInit (xref2rxsched_t rxsched) {
         LMICOS_logEventUint32("rxschedInit: enrypt failed", seErr);
     }
     u1_t intvExp = rxsched->intvExp;
-    ostime_t off = os_rlsbf2(LMIC.frame) & (0x0FFF >> (7 - intvExp)); // random offset (slot units)
+    ostime_t off = os_rlsbf2(frame) & (0x0FFF >> (7 - intvExp)); // random offset (slot units)
     rxsched->rxbase = (LMIC.bcninfo.txtime +
                        BCN_RESERVE_osticks +
                        ms2osticks(BCN_SLOT_SPAN_ms * off)); // random offset osticks
@@ -3065,10 +3065,18 @@ void LMIC_tryRejoin (void) {
 void LMIC_setSession (u4_t netid, devaddr_t devaddr, xref2u1_t nwkKey, xref2u1_t artKey) {
     LMIC.netid = netid;
     LMIC.devaddr = devaddr;
-    if( nwkKey != (xref2u1_t)0 )
+    if( nwkKey != (xref2u1_t)0 ) {
         os_copyMem(LMIC.nwkKey, nwkKey, 16);
-    if( artKey != (xref2u1_t)0 )
+        LMIC_SecureElement_Aes128Key_t seKey;
+        os_copyMem(seKey.bytes, nwkKey, 16);
+        LMIC_SecureElement_setNwkSKey(&seKey, LMIC_SecureElement_KeySelector_Unicast);
+    }
+    if( artKey != (xref2u1_t)0 ) {
         os_copyMem(LMIC.artKey, artKey, 16);
+        LMIC_SecureElement_Aes128Key_t seKey;
+        os_copyMem(seKey.bytes, artKey, 16);
+        LMIC_SecureElement_setAppSKey(&seKey, LMIC_SecureElement_KeySelector_Unicast);
+    }
 
     LMICbandplan_setSessionInitDefaultChannels();
 

--- a/src/se/drivers/default/lmic_se_default.c
+++ b/src/se/drivers/default/lmic_se_default.c
@@ -144,6 +144,24 @@ LMIC_SecureElement_Default_setAppKey(const LMIC_SecureElement_Aes128Key_t *pAppK
 
 /*!
 
+\copydoc LMIC_SecureElement_setNwkSKey_t
+
+\par "Implementation Notes"
+In the default secure element, the nwkskey is stored in a static variable without obfuscation.
+This function is used by ABP initialization to load the network session key.
+
+*/
+
+LMIC_SecureElement_Error_t
+LMIC_SecureElement_Default_setNwkSKey(const LMIC_SecureElement_Aes128Key_t *pNwkSKey, LMIC_SecureElement_KeySelector_t iKey) {
+	if (iKey != LMIC_SecureElement_KeySelector_Unicast)
+		return LMIC_SecureElement_Error_InvalidParameter;
+	s_nwkSKey = *pNwkSKey;
+	return LMIC_SecureElement_Error_OK;
+}
+
+/*!
+
 \copydoc LMIC_SecureElement_getNwkSKey_t
 
 \par "Implementation Notes"
@@ -157,6 +175,24 @@ LMIC_SecureElement_Default_getNwkSKey(LMIC_SecureElement_Aes128Key_t *pNwkSKey, 
 	if (iKey != LMIC_SecureElement_KeySelector_Unicast)
 		return LMIC_SecureElement_Error_InvalidParameter;
 	os_copyMem(pNwkSKey->bytes, s_nwkSKey.bytes, sizeof(pNwkSKey->bytes));
+	return LMIC_SecureElement_Error_OK;
+}
+
+/*!
+
+\copydoc LMIC_SecureElement_setAppSKey_t
+
+\par "Implementation Notes"
+In the default secure element, the appskey is stored in a static variable without obfuscation.
+This function is used by ABP initialization to load the application session key.
+
+*/
+
+LMIC_SecureElement_Error_t
+LMIC_SecureElement_Default_setAppSKey(const LMIC_SecureElement_Aes128Key_t *pAppSKey, LMIC_SecureElement_KeySelector_t iKey) {
+	if (iKey != LMIC_SecureElement_KeySelector_Unicast)
+		return LMIC_SecureElement_Error_InvalidParameter;
+	s_appSKey = *pAppSKey;
 	return LMIC_SecureElement_Error_OK;
 }
 


### PR DESCRIPTION
The Secure Element abstraction introduced in v6.0.0 stores session keys
in its own private storage (s_nwkSKey / s_appSKey), but LMIC_setSession()
was never updated to push keys into the SE. As a result, ABP sessions
used zero keys for all crypto, causing every uplink MIC to be wrong and
every downlink MIC check to fail.

Fix 1: Implement LMIC_SecureElement_Default_setNwkSKey() and
LMIC_SecureElement_Default_setAppSKey() in the default SE driver.
These were declared in the interface macro but had no implementation.

Fix 2: Update LMIC_setSession() to call LMIC_SecureElement_setNwkSKey()
and LMIC_SecureElement_setAppSKey() so the SE sees the ABP session keys.

Fix 3: Fix rxschedInit() reading from LMIC.frame instead of the local
frame[] buffer that was just AES-encrypted for ping slot scheduling.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>