### PR TITLE
Sleep/Wake State API — ABP, scope and OTAA compatibility

### DIFF
--- a/examples/ttn-abp-sleep/ttn-abp-sleep.ino
+++ b/examples/ttn-abp-sleep/ttn-abp-sleep.ino
@@ -1,0 +1,315 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Thomas Telkamp and Matthijs Kooijman
+ * Copyright (c) 2018 Terry Moore, MCCI
+ * Copyright (c) 2026 Pontus Oldberg, iLabs
+ *
+ * Permission is hereby granted, free of charge, to anyone
+ * obtaining a copy of this document and accompanying files,
+ * to do whatever they want with them without any restriction,
+ * including, but not limited to, copying, modification and redistribution.
+ * NO WARRANTY OF ANY KIND IS PROVIDED.
+ *
+ * This example demonstrates how to use the LMIC sleep/wake state API to
+ * safely deep-sleep a LoRaWAN ABP device between transmissions. It builds
+ * on the ttn-abp example and adds:
+ *
+ *   - LMIC_getSleepState() / LMIC_setSleepState() to persist the LMIC
+ *     state (frame counters, RX parameters, sticky MAC ACKs) across
+ *     power cycles.
+ *   - EV_SLEEP_READY event, which fires once LMIC has fulfilled all MAC
+ *     obligations for the current wake cycle (including any MAC-command
+ *     response uplinks). This is the correct and safe point to save state
+ *     and enter deep sleep.
+ *
+ * Platform-specific deep sleep and non-volatile storage are left as stubs
+ * (see saveSleepState(), loadSleepState(), enterDeepSleep()) — replace
+ * these with your hardware's NVRAM/EEPROM and sleep APIs.
+ *
+ * Why EV_SLEEP_READY instead of EV_TXCOMPLETE?
+ * --------------------------------------------
+ * After EV_TXCOMPLETE the network may have sent MAC commands (e.g.
+ * NewChannelReq, RxTimingSetupReq) that require an acknowledgement uplink
+ * on port 0. LMIC schedules this follow-up automatically; if the device
+ * sleeps at EV_TXCOMPLETE the ACK is never sent and the network will keep
+ * re-sending the command every downlink. EV_SLEEP_READY fires only after
+ * all such obligations are done.
+ *
+ * Frame counter persistence (LoRaWAN §4.3.1):
+ * --------------------------------------------
+ * ABP devices MUST persist seqnoUp/seqnoDn across power cycles or the
+ * network server will reject frames as replays. LMIC_getSleepState()
+ * captures both counters (and other session parameters); restoring them
+ * with LMIC_setSleepState() after LMIC_reset() keeps the session alive.
+ *
+ * Do not forget to define the radio type correctly in
+ * arduino-lmic/project_config/lmic_project_config.h or from your BOARDS.txt.
+ *
+ *******************************************************************************/
+
+#include <lmic.h>
+#include <hal/hal.h>
+#include <SPI.h>
+
+//
+// For normal use, we require that you edit the sketch to replace FILLMEIN
+// with values assigned by the TTN console. However, for regression tests,
+// we want to be able to compile these scripts. The regression tests define
+// COMPILE_REGRESSION_TEST, and in that case we define FILLMEIN to a non-
+// working but innocuous value.
+//
+#ifdef COMPILE_REGRESSION_TEST
+# define FILLMEIN 0
+#else
+# warning "You must replace the values marked FILLMEIN with real values from the TTN control panel!"
+# define FILLMEIN (#dont edit this, edit the lines that use FILLMEIN)
+#endif
+
+// LoRaWAN NwkSKey, network session key
+// This should be in big-endian (aka msb).
+static const PROGMEM u1_t NWKSKEY[16] = { FILLMEIN };
+
+// LoRaWAN AppSKey, application session key
+// This should also be in big-endian (aka msb).
+static const u1_t PROGMEM APPSKEY[16] = { FILLMEIN };
+
+// LoRaWAN end-device address (DevAddr)
+// See http://thethingsnetwork.org/wiki/AddressSpace
+// The library converts the address to network byte order as needed, so this
+// should be in big-endian (aka msb) too.
+static const u4_t DEVADDR = FILLMEIN ; // <-- Change this address for every node!
+
+// These callbacks are only used in over-the-air activation, so they are
+// left empty here (we cannot leave them out completely unless
+// DISABLE_JOIN is set in arduino-lmic/project_config/lmic_project_config.h,
+// otherwise the linker will complain).
+void os_getArtEui (u1_t* buf) { }
+void os_getDevEui (u1_t* buf) { }
+void os_getDevKey (u1_t* buf) { }
+
+static uint8_t mydata[] = "Hello, world!";
+static osjob_t sendjob;
+
+// How long to sleep between transmissions (seconds).
+// Actual air-time may extend this due to duty-cycle enforcement.
+const unsigned TX_INTERVAL = 60;
+
+// Persisted LMIC state: frame counters, RX parameters, sticky MAC ACKs.
+// Allocated in RAM; loaded from non-volatile storage on each wake.
+static lmic_sleep_state_t sleepState;
+
+// Flag: true if non-volatile storage contained a valid saved state.
+static bool hasSavedState = false;
+
+// ---------------------------------------------------------------------------
+// Platform stubs — replace with your hardware's NVRAM/EEPROM and sleep API.
+// ---------------------------------------------------------------------------
+
+// Save sleepState to non-volatile storage.
+// Called from EV_SLEEP_READY before entering deep sleep.
+static void saveSleepState() {
+    // Example (EEPROM):
+    //   EEPROM.put(0, sleepState);
+    //   EEPROM.commit();
+    //
+    // TODO: implement for your platform.
+}
+
+// Load previously saved state into sleepState.
+// Returns true if valid data was found, false on first boot or after erasure.
+static bool loadSleepState() {
+    // Example (EEPROM):
+    //   EEPROM.get(0, sleepState);
+    //   return /* validate magic/CRC */ true;
+    //
+    // TODO: implement for your platform.
+    return false;
+}
+
+// Enter deep sleep for the given number of seconds, then reset/wake.
+// On many platforms a watchdog timer or RTC alarm triggers a full reset,
+// so execution resumes from setup() on the next wake cycle.
+static void enterDeepSleep(unsigned seconds) {
+    // Example (ESP32):
+    //   esp_sleep_enable_timer_wakeup((uint64_t)seconds * 1000000ULL);
+    //   esp_deep_sleep_start();
+    //
+    // TODO: implement for your platform.
+    // Fallback: busy-wait (for testing on platforms without real sleep support).
+    delay((unsigned long)seconds * 1000UL);
+    do_send(&sendjob);
+}
+
+// ---------------------------------------------------------------------------
+
+// Pin mapping — adjust for your board.
+const lmic_pinmap lmic_pins = {
+    .nss = 8,
+    .rxtx = LMIC_UNUSED_PIN,
+    .rst = 4,
+    .dio = {6, 5, LMIC_UNUSED_PIN},
+};
+
+void onEvent (ev_t ev) {
+    Serial.print(os_getTime());
+    Serial.print(": ");
+    switch(ev) {
+        case EV_SCAN_TIMEOUT:
+            Serial.println(F("EV_SCAN_TIMEOUT"));
+            break;
+        case EV_BEACON_FOUND:
+            Serial.println(F("EV_BEACON_FOUND"));
+            break;
+        case EV_BEACON_MISSED:
+            Serial.println(F("EV_BEACON_MISSED"));
+            break;
+        case EV_BEACON_TRACKED:
+            Serial.println(F("EV_BEACON_TRACKED"));
+            break;
+        case EV_JOINING:
+            Serial.println(F("EV_JOINING"));
+            break;
+        case EV_JOINED:
+            Serial.println(F("EV_JOINED"));
+            break;
+        case EV_JOIN_FAILED:
+            Serial.println(F("EV_JOIN_FAILED"));
+            break;
+        case EV_REJOIN_FAILED:
+            Serial.println(F("EV_REJOIN_FAILED"));
+            break;
+        case EV_TXCOMPLETE:
+            Serial.println(F("EV_TXCOMPLETE (includes waiting for RX windows)"));
+            if (LMIC.txrxFlags & TXRX_ACK)
+                Serial.println(F("Received ack"));
+            if (LMIC.dataLen) {
+                Serial.print(F("Received "));
+                Serial.print(LMIC.dataLen);
+                Serial.println(F(" bytes of payload"));
+            }
+            // Do NOT sleep here. If the network sent MAC commands (e.g.
+            // NewChannelReq, RxTimingSetupReq), LMIC needs to send an
+            // acknowledgement uplink first. EV_SLEEP_READY fires once
+            // all obligations are fulfilled.
+            break;
+        case EV_SLEEP_READY:
+            // All MAC obligations for this wake cycle are done — safe to
+            // persist state and power down.
+            Serial.println(F("EV_SLEEP_READY"));
+            LMIC_getSleepState(&sleepState);
+            saveSleepState();
+            Serial.flush();
+            enterDeepSleep(TX_INTERVAL);
+            break;
+        case EV_LOST_TSYNC:
+            Serial.println(F("EV_LOST_TSYNC"));
+            break;
+        case EV_RESET:
+            Serial.println(F("EV_RESET"));
+            break;
+        case EV_RXCOMPLETE:
+            Serial.println(F("EV_RXCOMPLETE"));
+            break;
+        case EV_LINK_DEAD:
+            Serial.println(F("EV_LINK_DEAD"));
+            break;
+        case EV_LINK_ALIVE:
+            Serial.println(F("EV_LINK_ALIVE"));
+            break;
+        case EV_TXSTART:
+            Serial.println(F("EV_TXSTART"));
+            break;
+        case EV_TXCANCELED:
+            Serial.println(F("EV_TXCANCELED"));
+            break;
+        case EV_RXSTART:
+            /* do not print anything -- it wrecks timing */
+            break;
+        case EV_JOIN_TXCOMPLETE:
+            Serial.println(F("EV_JOIN_TXCOMPLETE: no JoinAccept"));
+            break;
+        default:
+            Serial.print(F("Unknown event: "));
+            Serial.println((unsigned) ev);
+            break;
+    }
+}
+
+void do_send(osjob_t* j){
+    // Check if there is not a current TX/RX job running
+    if (LMIC.opmode & OP_TXRXPEND) {
+        Serial.println(F("OP_TXRXPEND, not sending"));
+    } else {
+        LMIC_setTxData2(1, mydata, sizeof(mydata)-1, 0);
+        Serial.println(F("Packet queued"));
+    }
+}
+
+void setup() {
+    while (!Serial);
+    Serial.begin(115200);
+    delay(100);
+    Serial.println(F("Starting"));
+
+    #ifdef VCC_ENABLE
+    pinMode(VCC_ENABLE, OUTPUT);
+    digitalWrite(VCC_ENABLE, HIGH);
+    delay(1000);
+    #endif
+
+    // LMIC init
+    os_init();
+    LMIC_reset();
+
+    // Restore session parameters from non-volatile storage.
+    // This MUST be called after LMIC_reset() and LMIC_setSession() so that
+    // frame counters and RX parameters survive power cycles.
+    hasSavedState = loadSleepState();
+    if (hasSavedState) {
+        Serial.println(F("Restored LMIC sleep state"));
+        LMIC_setSleepState(&sleepState);
+    }
+
+    // Set static session parameters.
+    #ifdef PROGMEM
+    uint8_t appskey[sizeof(APPSKEY)];
+    uint8_t nwkskey[sizeof(NWKSKEY)];
+    memcpy_P(appskey, APPSKEY, sizeof(APPSKEY));
+    memcpy_P(nwkskey, NWKSKEY, sizeof(NWKSKEY));
+    LMIC_setSession(0x13, DEVADDR, nwkskey, appskey);
+    #else
+    LMIC_setSession(0x13, DEVADDR, NWKSKEY, APPSKEY);
+    #endif
+
+    #if defined(CFG_eu868)
+    LMIC_setupChannel(0, 868100000, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_CENTI);
+    LMIC_setupChannel(1, 868300000, DR_RANGE_MAP(DR_SF12, DR_SF7B), BAND_CENTI);
+    LMIC_setupChannel(2, 868500000, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_CENTI);
+    LMIC_setupChannel(3, 867100000, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_CENTI);
+    LMIC_setupChannel(4, 867300000, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_CENTI);
+    LMIC_setupChannel(5, 867500000, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_CENTI);
+    LMIC_setupChannel(6, 867700000, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_CENTI);
+    LMIC_setupChannel(7, 867900000, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_CENTI);
+    LMIC_setupChannel(8, 868800000, DR_RANGE_MAP(DR_FSK,  DR_FSK),  BAND_MILLI);
+    #elif defined(CFG_us915) || defined(CFG_au915)
+    LMIC_selectSubBand(1);
+    #elif defined(CFG_as923)
+    // ... extra definitions for channels 2..n here
+    #elif defined(CFG_kr920)
+    // ... extra definitions for channels 3..n here.
+    #elif defined(CFG_in866)
+    // ... extra definitions for channels 3..n here.
+    #else
+    # error Region not supported
+    #endif
+
+    LMIC_setLinkCheckMode(0);
+    LMIC.dn2Dr = DR_SF9;
+    LMIC_setDrTxpow(DR_SF7, 14);
+
+    // Start first transmission
+    do_send(&sendjob);
+}
+
+void loop() {
+    os_runloop_once();
+}

--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -2403,6 +2403,13 @@ static bit_t processDnData_txcomplete(void) {
         reportEventNoUpdate(EV_LINK_ALIVE);
     }
     reportEventAndUpdate(EV_TXCOMPLETE);
+    // Fire EV_SLEEP_READY when there are no follow-up transmissions pending
+    // (i.e. no port-0 MAC-response uplink queued by processDnData_txcomplete).
+    // This signals to power-cycling applications that it is safe to call
+    // LMIC_getSleepState() and then cut power.
+    if (LMIC_isSleepReady()) {
+        reportEventAndUpdate(EV_SLEEP_READY);
+    }
     // If we haven't heard from NWK in a while although we asked for a sign
     // assume link is dead - notify application and keep going
     if( LMIC.adrAckReq > LINK_CHECK_DEAD ) {
@@ -3202,6 +3209,77 @@ u1_t LMIC_setBatteryLevel(u1_t uBattLevel) {
 
     LMIC.client.devStatusAns_battery = uBattLevel;
     return result;
+}
+
+// ============================================================================
+// Sleep/wake API
+// ============================================================================
+
+///
+/// \brief Check whether LMIC has fulfilled all pending MAC obligations and it
+///        is safe to power down.
+///
+/// \returns Non-zero when no follow-up uplink is queued.  Zero means LMIC has
+///          a port-0 MAC-response uplink (e.g. NewChannelAns) still to send,
+///          or an in-progress TX/RX cycle is not yet complete.
+///
+bit_t LMIC_isSleepReady(void) {
+    return (LMIC.opmode & (OP_TXDATA | OP_POLL | OP_TXRXPEND)) == 0;
+}
+
+///
+/// \brief Capture the LMIC fields that must persist across a power cycle.
+///
+/// \param pState  Pointer to a caller-allocated \c lmic_sleep_state_t.
+///
+/// \details Only call this when \c LMIC_isSleepReady() returns non-zero.
+///          Calling it while a TX/RX cycle or MAC follow-up is in progress
+///          will capture an incomplete snapshot.
+///
+void LMIC_getSleepState(lmic_sleep_state_t *pState) {
+    pState->seqnoUp     = LMIC.seqnoUp;
+    pState->seqnoDn     = LMIC.seqnoDn;
+    pState->rxDelay     = LMIC.rxDelay;
+    pState->dn2Dr       = LMIC.dn2Dr;
+    pState->dn2Freq     = LMIC.dn2Freq;
+    pState->rx1DrOffset = LMIC.rx1DrOffset;
+#if !defined(DISABLE_MCMD_RXParamSetupReq)
+    pState->dn2Ans      = LMIC.dn2Ans;
+#endif
+#if !defined(DISABLE_MCMD_DlChannelReq)
+    pState->macDlChannelAns = LMIC.macDlChannelAns;
+#endif
+#if !defined(DISABLE_MCMD_RXTimingSetupReq)
+    pState->macRxTimingSetupAns = LMIC.macRxTimingSetupAns;
+#endif
+}
+
+///
+/// \brief Restore previously captured sleep state into LMIC.
+///
+/// \param pState  Pointer to a \c lmic_sleep_state_t populated by a prior call
+///                to \c LMIC_getSleepState().
+///
+/// \details MUST be called AFTER \c LMIC_reset() and \c LMIC_setSession() (ABP)
+///          or after a successful OTAA join, so that these calls do not
+///          overwrite the restored values.
+///
+void LMIC_setSleepState(const lmic_sleep_state_t *pState) {
+    LMIC.seqnoUp     = pState->seqnoUp;
+    LMIC.seqnoDn     = pState->seqnoDn;
+    LMIC.rxDelay     = pState->rxDelay;
+    LMIC.dn2Dr       = pState->dn2Dr;
+    LMIC.dn2Freq     = pState->dn2Freq;
+    LMIC.rx1DrOffset = pState->rx1DrOffset;
+#if !defined(DISABLE_MCMD_RXParamSetupReq)
+    LMIC.dn2Ans      = pState->dn2Ans;
+#endif
+#if !defined(DISABLE_MCMD_DlChannelReq)
+    LMIC.macDlChannelAns = pState->macDlChannelAns;
+#endif
+#if !defined(DISABLE_MCMD_RXTimingSetupReq)
+    LMIC.macRxTimingSetupAns = pState->macRxTimingSetupAns;
+#endif
 }
 
 ///

--- a/src/lmic/lmic.h
+++ b/src/lmic/lmic.h
@@ -351,7 +351,8 @@ enum _ev_t { EV_SCAN_TIMEOUT=1, EV_BEACON_FOUND,
              EV_JOINED, EV_RFU1, EV_JOIN_FAILED, EV_REJOIN_FAILED,
              EV_TXCOMPLETE, EV_LOST_TSYNC, EV_RESET,
              EV_RXCOMPLETE, EV_LINK_DEAD, EV_LINK_ALIVE, EV_SCAN_FOUND,
-             EV_TXSTART, EV_TXCANCELED, EV_RXSTART, EV_JOIN_TXCOMPLETE };
+             EV_TXSTART, EV_TXCANCELED, EV_RXSTART, EV_JOIN_TXCOMPLETE,
+             EV_SLEEP_READY };
 typedef enum _ev_t ev_t;
 
 /// \brief Macro to initialize a normal table of event strings
@@ -362,7 +363,8 @@ typedef enum _ev_t ev_t;
     "EV_JOINED", "EV_RFU1", "EV_JOIN_FAILED", "EV_REJOIN_FAILED",           \
     "EV_TXCOMPLETE", "EV_LOST_TSYNC", "EV_RESET",                           \
     "EV_RXCOMPLETE", "EV_LINK_DEAD", "EV_LINK_ALIVE", "EV_SCAN_FOUND",      \
-    "EV_TXSTART", "EV_TXCANCELED", "EV_RXSTART", "EV_JOIN_TXCOMPLETE"
+    "EV_TXSTART", "EV_TXCANCELED", "EV_RXSTART", "EV_JOIN_TXCOMPLETE", \
+    "EV_SLEEP_READY"
 
 /// \brief Macro to initialize a compressed string of event strings
 /// \details
@@ -377,7 +379,8 @@ typedef enum _ev_t ev_t;
     "EV_JOINED\0" "EV_RFU1\0" "EV_JOIN_FAILED\0" "EV_REJOIN_FAILED\0"       \
     "EV_TXCOMPLETE\0" "EV_LOST_TSYNC\0" "EV_RESET\0"                        \
     "EV_RXCOMPLETE\0" "EV_LINK_DEAD\0" "EV_LINK_ALIVE\0" "EV_SCAN_FOUND\0"  \
-    "EV_TXSTART\0" "EV_TXCANCELED\0" "EV_RXSTART\0" "EV_JOIN_TXCOMPLETE\0"
+    "EV_TXSTART\0" "EV_TXCANCELED\0" "EV_RXSTART\0" "EV_JOIN_TXCOMPLETE\0" \
+    "EV_SLEEP_READY\0"
 
 /// \brief LMIC error codes
 enum lmic_tx_error_e {
@@ -940,6 +943,91 @@ DECLARE_LMIC; //!< \internal
 
 /****************************************************************************\
 |
+|   Sleep/wake state for power-cycling devices
+|
+\****************************************************************************/
+
+/// \brief Minimal LMIC state that must survive a power cycle for ABP devices.
+///
+/// \details For devices that cut power to the MCU and radio between transmissions
+/// (e.g. using a PMC or other power management IC), this structure holds the
+/// fields that the LoRaWAN spec requires to be retained, plus the fields LMIC
+/// uses internally for correct session behaviour:
+///
+///  - Frame counters (LoRaWAN §4.3.1 — ABP devices MUST persist these).
+///  - RX window parameters set by the network via MAC commands (rxDelay,
+///    dn2Dr, dn2Freq, rx1DrOffset).  Without these the device opens RX1/RX2
+///    at the wrong time or frequency after a power cycle.
+///  - Sticky MAC ACK flags (dn2Ans, macDlChannelAns, macRxTimingSetupAns —
+///    LoRaWAN §5.4/§5.7).  LMIC must re-send these in every uplink until the
+///    network acknowledges them via a Class A downlink.
+///
+/// Usage pattern (ABP):
+/// \code
+///   lmic_sleep_state_t sleepState;
+///
+///   void onEvent(ev_t ev) {
+///       if (ev == EV_SLEEP_READY) {
+///           LMIC_getSleepState(&sleepState);
+///           // persist sleepState to NVRAM / flash
+///           // then power off
+///       }
+///   }
+///
+///   void setup() {
+///       os_init();
+///       LMIC_reset();
+///       LMIC_setSession(...);   // channel plan, ADR settings …
+///       // restore from NVRAM / flash:
+///       LMIC_setSleepState(&sleepState);
+///       do_send(&sendjob);
+///   }
+/// \endcode
+typedef struct lmic_sleep_state_s {
+    /// Uplink frame counter (FCntUp). LoRaWAN §4.3.1 requires ABP devices to
+    /// persist this across power cycles so the network can reject replays.
+    u4_t    seqnoUp;
+
+    /// Downlink frame counter (FCntDown). Used to detect replayed downlinks.
+    u4_t    seqnoDn;
+
+    /// RX1 delay in seconds as set by RxTimingSetupReq.  Default is 1 s.
+    /// If the network sends RxTimingSetupReq and the device loses this value
+    /// on power-down, the device will open its RX1 window at the wrong time
+    /// and miss all downlinks until the network re-negotiates the parameter.
+    u1_t    rxDelay;
+
+    /// RX2 datarate index (set by RxParamSetupReq).
+    u1_t    dn2Dr;
+
+    /// RX2 frequency in Hz (set by RxParamSetupReq).
+    u4_t    dn2Freq;
+
+    /// RX1 datarate offset (set by RxParamSetupReq).
+    u1_t    rx1DrOffset;
+
+#if !defined(DISABLE_MCMD_RXParamSetupReq)
+    /// Pending RxParamSetupAns sticky response (LoRaWAN §5.4).
+    /// Non-zero means the ACK must be included in every uplink until the
+    /// network acknowledges it.  The encoding follows LMIC internals:
+    /// bit 7 = pending, bit 6 = "skip this TX" (first cycle after receipt),
+    /// bits 2:0 = the three acceptance bits.
+    u1_t    dn2Ans;
+#endif
+
+#if !defined(DISABLE_MCMD_DlChannelReq)
+    /// Pending DlChannelAns sticky response (LoRaWAN §5.4).
+    u1_t    macDlChannelAns;
+#endif
+
+#if !defined(DISABLE_MCMD_RXTimingSetupReq)
+    /// Pending RxTimingSetupAns sticky response (LoRaWAN §5.7).
+    u1_t    macRxTimingSetupAns;
+#endif
+} lmic_sleep_state_t;
+
+/****************************************************************************\
+|
 |   API functions
 |
 \****************************************************************************/
@@ -1010,6 +1098,33 @@ int LMIC_findNextChannel(uint16_t *, const uint16_t *, uint16_t, int);
 
 u1_t LMIC_getBatteryLevel(void);
 u1_t LMIC_setBatteryLevel(u1_t /* uBattLevel */);
+
+// Sleep/wake API for power-cycling devices
+//
+// Call LMIC_isSleepReady() inside onEvent(EV_TXCOMPLETE) to check whether it
+// is safe to power down, or handle the EV_SLEEP_READY event which is fired
+// automatically by LMIC when all MAC obligations (including any follow-up
+// port-0 MAC response uplinks) have been fulfilled.
+//
+// Typical flow:
+//   onEvent(EV_SLEEP_READY)  ->  LMIC_getSleepState()  ->  persist to NVRAM  ->  power off
+//   setup()  ->  LMIC_reset() + LMIC_setSession()  ->  LMIC_setSleepState()  ->  do_send()
+
+/// Returns non-zero when LMIC has no pending transmissions and it is safe to
+/// save state and power down.  A zero return means LMIC still has a follow-up
+/// uplink queued (e.g. a port-0 MAC response after receiving NewChannelReq).
+bit_t LMIC_isSleepReady(void);
+
+/// Populate \p pState with the LMIC fields that must survive a power cycle.
+/// Only call this when LMIC_isSleepReady() returns non-zero (i.e. from the
+/// EV_SLEEP_READY handler), otherwise the captured state may be incomplete.
+void  LMIC_getSleepState(lmic_sleep_state_t *pState);
+
+/// Restore previously captured sleep state into the running LMIC instance.
+/// MUST be called after LMIC_reset() and LMIC_setSession() (ABP) or after a
+/// successful OTAA join, so that the freshly zeroed fields are overwritten
+/// with the persisted values rather than the other way around.
+void  LMIC_setSleepState(const lmic_sleep_state_t *pState);
 
 // APIs for client half of compliance.
 typedef u1_t lmic_compliance_rx_action_t;


### PR DESCRIPTION
This PR introduces lmic_sleep_state_t, LMIC_getSleepState(), LMIC_setSleepState(), LMIC_isSleepReady(), and  EV_SLEEP_READY to give applications a clean, spec-compliant way to deep-sleep between transmissions without losing LoRaWAN session state.

The implementation has been reviewed against OTAA operation and does not break it:                                                                                                              

  - EV_SLEEP_READY fires based on opmode flags that are agnostic to activation method — it works correctly for both ABP and OTAA post-join cycles.
  - lmic_sleep_state_t captures only post-session parameters (frame counters, RX window configuration, sticky MAC ACKs). It makes no assumptions about how the session was established.
  - LMIC_setSleepState() is designed to be called after LMIC_setSession(), so OTAA applications that restore their session keys from storage and then call LMIC_setSleepState() will behave correctly.
  - No existing OTAA specific code paths are modified.

Full OTAA sleep support, persisting devNonce and session keys across power cycles, and the join-vs-restore wake logic is intentionally deferred to a follow-up PR to keep this change focused and reviewable.

The included ttn-abp-sleep example demonstrates the API for ABP. A corresponding ttn-otaa-sleep example will be part of the OTAA follow-up.