### PR TITLE
Fix SX126x DIO2 RF switch check treating function as pointer

### DIFF
--- a/src/lmic/radio_sx126x.c
+++ b/src/lmic/radio_sx126x.c
@@ -774,7 +774,7 @@ void radio_config(void) {
     }
 
     // If the board has RfSwitch, switch on
-    if (lmic_hal_queryUsingDIO2AsRfSwitch) {
+    if (lmic_hal_queryUsingDIO2AsRfSwitch()) {
         setDio2AsRfSwitchCtrl();
     }
 


### PR DESCRIPTION
lmic_hal_queryUsingDIO2AsRfSwitch was used without () so it evaluated as a function pointer (always non-null/true) instead of calling the function. This caused DIO2 to always be configured as RF switch regardless of the HAL configuration.