### PR TITLE
Fix uninitialized loop variable in SX126x setRx()

### DIFF
--- a/src/lmic/radio_sx126x.c
+++ b/src/lmic/radio_sx126x.c
@@ -336,7 +336,7 @@ static void setRx(u1_t timeout[SX126X_TIMEOUT_LEN]) {
     // It is advised to add the following commands after ANY Rx with Timeout active sequence,
     // which stop the RTC and clear the timeout event, if any.
     u1_t hasTimeout = 0;
-    for (u1_t i; i < SX126X_TIMEOUT_LEN; i++) {
+    for (u1_t i = 0; i < SX126X_TIMEOUT_LEN; i++) {
         if ((timeout[i] != 0x00) && (timeout[i] !=0xFF)) {
             hasTimeout = 1;
             break;


### PR DESCRIPTION
The loop variable i in the workaround 15.3 timeout detection loop was declared without initialization (u1_t i), making the comparison i < SX126X_TIMEOUT_LEN undefined behavior. The loop could start at any value, causing the RTC workaround to be skipped or the buffer to be read out of bounds.