### PR TITLE
Add board-configurable SX126x crystal oscillator trim support

### DIFF
--- a/src/arduino_lmic_hal_configuration.h
+++ b/src/arduino_lmic_hal_configuration.h
@@ -20,6 +20,7 @@ Author:
 
 #include <stdint.h>
 #include "lmic/lmic_env.h"
+#include "lmic/hal.h"
 
 namespace Arduino_LMIC {
 
@@ -95,6 +96,12 @@ public:
 	virtual bool queryUsingDcdc(void) { return false; }
 	virtual bool queryUsingDIO2AsRfSwitch(void) { return false; }
 	virtual bool queryUsingDIO3AsTCXOSwitch(void) { return false; }
+
+	// SX126x crystal oscillator trim (registers XTATrim/XTBTrim, 0x0911/0x0912).
+	// Valid trim values are 0x00-0x3F; chip reset default is 0x05 for both.
+	// Return LMIC_HAL_SX126X_XTAL_TRIM_USE_DEFAULT (0xFF) to leave the chip reset value untouched.
+	virtual uint8_t querySX126xXTATrim(void) { return LMIC_HAL_SX126X_XTAL_TRIM_USE_DEFAULT; }
+	virtual uint8_t querySX126xXTBTrim(void) { return LMIC_HAL_SX126X_XTAL_TRIM_USE_DEFAULT; }
 
 	// compute desired transmit power policy.  HopeRF needs
 	// (and previous versions of this library always chose)

--- a/src/hal/hal.cpp
+++ b/src/hal/hal.cpp
@@ -570,6 +570,14 @@ bit_t lmic_hal_queryUsingDIO3AsTCXOSwitch(void) {
     return pHalConfig->queryUsingDIO3AsTCXOSwitch();
 }
 
+uint8_t lmic_hal_querySX126xXTATrim(void) {
+    return pHalConfig->querySX126xXTATrim();
+}
+
+uint8_t lmic_hal_querySX126xXTBTrim(void) {
+    return pHalConfig->querySX126xXTBTrim();
+}
+
 uint8_t lmic_hal_getTxPowerPolicy(
     u1_t inputPolicy,
     s1_t requestedPower,

--- a/src/lmic/hal.h
+++ b/src/lmic/hal.h
@@ -171,6 +171,18 @@ bit_t lmic_hal_queryUsingDIO2AsRfSwitch(void);
 /* SX126x function: find out if the board is configured to control a TCXO with modem DIO3 */
 bit_t lmic_hal_queryUsingDIO3AsTCXOSwitch(void);
 
+/* Sentinel returned by lmic_hal_querySX126xXTATrim/XTBTrim when the board
+   does not specify a trim value and the chip reset default should be used. */
+#define LMIC_HAL_SX126X_XTAL_TRIM_USE_DEFAULT  ((uint8_t) 0xFF)
+
+/* SX126x function: get XTA crystal trim value (0x00-0x3F), or
+   LMIC_HAL_SX126X_XTAL_TRIM_USE_DEFAULT to leave chip reset value unchanged */
+uint8_t lmic_hal_querySX126xXTATrim(void);
+
+/* SX126x function: get XTB crystal trim value (0x00-0x3F), or
+   LMIC_HAL_SX126X_XTAL_TRIM_USE_DEFAULT to leave chip reset value unchanged */
+uint8_t lmic_hal_querySX126xXTBTrim(void);
+
 /* represent the various radio TX power policy */
 enum	{
 	LMICHAL_radio_tx_power_policy_rfo	= 0,

--- a/src/lmic/radio_sx126x.c
+++ b/src/lmic/radio_sx126x.c
@@ -785,14 +785,12 @@ void radio_config(void) {
     // Apply board-specific crystal oscillator trim values if configured.
     // Some board designs require different XTA/XTB trim capacitance than the
     // chip reset default (0x05) for adequate frequency accuracy.
-    {
-        uint8_t xta = lmic_hal_querySX126xXTATrim();
-        uint8_t xtb = lmic_hal_querySX126xXTBTrim();
-        if (xta != LMIC_HAL_SX126X_XTAL_TRIM_USE_DEFAULT)
-            writeRegister(XTATrim, xta);
-        if (xtb != LMIC_HAL_SX126X_XTAL_TRIM_USE_DEFAULT)
-            writeRegister(XTBTrim, xtb);
-    }
+    uint8_t xta = lmic_hal_querySX126xXTATrim();
+    uint8_t xtb = lmic_hal_querySX126xXTBTrim();
+    if (xta != LMIC_HAL_SX126X_XTAL_TRIM_USE_DEFAULT)
+        writeRegister(XTATrim, xta);
+    if (xtb != LMIC_HAL_SX126X_XTAL_TRIM_USE_DEFAULT)
+        writeRegister(XTBTrim, xtb);
 
     // DC-DC regulator is hardware dependent
     if (lmic_hal_queryUsingDcdc()) {

--- a/src/lmic/radio_sx126x.c
+++ b/src/lmic/radio_sx126x.c
@@ -774,7 +774,7 @@ void radio_config(void) {
     }
 
     // If the board has RfSwitch, switch on
-    if (lmic_hal_queryUsingDIO2AsRfSwitch) {
+    if (lmic_hal_queryUsingDIO2AsRfSwitch()) {
         setDio2AsRfSwitchCtrl();
     }
 

--- a/src/lmic/radio_sx126x.c
+++ b/src/lmic/radio_sx126x.c
@@ -782,6 +782,18 @@ void radio_config(void) {
     // This register modification must be done after a Power On Reset, or a wake-up from cold Start.
     writeRegister(TxClampConfig, (readRegister(TxClampConfig) | 0x1E));
 
+    // Apply board-specific crystal oscillator trim values if configured.
+    // Some board designs require different XTA/XTB trim capacitance than the
+    // chip reset default (0x05) for adequate frequency accuracy.
+    {
+        uint8_t xta = lmic_hal_querySX126xXTATrim();
+        uint8_t xtb = lmic_hal_querySX126xXTBTrim();
+        if (xta != LMIC_HAL_SX126X_XTAL_TRIM_USE_DEFAULT)
+            writeRegister(XTATrim, xta);
+        if (xtb != LMIC_HAL_SX126X_XTAL_TRIM_USE_DEFAULT)
+            writeRegister(XTBTrim, xtb);
+    }
+
     // DC-DC regulator is hardware dependent
     if (lmic_hal_queryUsingDcdc()) {
         setRegulatorMode(0x01);


### PR DESCRIPTION
Some SX126x board designs require different XTA/XTB crystal trim
capacitance values than the chip reset default (0x05) for adequate
frequency accuracy. Previously there was no way to configure this
without modifying the driver.

Add querySX126xXTATrim() and querySX126xXTBTrim() virtual methods to
HalConfiguration_t following the existing pattern of queryUsingDcdc(),
queryUsingDIO2AsRfSwitch() etc. The default implementation returns
LMIC_HAL_SX126X_XTAL_TRIM_USE_DEFAULT (0xFF) which leaves the chip
reset value untouched, so existing boards are unaffected.

Board files that need custom trim values override the two methods:

    virtual uint8_t querySX126xXTATrim(void) override { return 0x12; }
    virtual uint8_t querySX126xXTBTrim(void) override { return 0x12; }

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>