### PR TITLE
Fix SX126x driver using stale LMIC.rxtime instead of LMIC.nextRxTime

### DIFF
--- a/src/lmic/lmic.h
+++ b/src/lmic/lmic.h
@@ -106,7 +106,7 @@ extern "C"{
 	((((major)*UINT32_C(1)) << 24) | (((minor)*UINT32_C(1)) << 16) | (((patch)*UINT32_C(1)) << 8) | (((local)*UINT32_C(1)) << 0))
 
 #define	ARDUINO_LMIC_VERSION    \
-    ARDUINO_LMIC_VERSION_CALC(6, 0, 2, 1)  /* 6.0.2-pre1 */
+    ARDUINO_LMIC_VERSION_CALC(6, 0, 2, 2)  /* 6.0.2-pre2 */
 
 #define	ARDUINO_LMIC_VERSION_GET_MAJOR(v)	\
 	((((v)*UINT32_C(1)) >> 24u) & 0xFFu)

--- a/src/lmic/radio_sx126x.c
+++ b/src/lmic/radio_sx126x.c
@@ -939,7 +939,7 @@ static void rxlate(u4_t nLate) {
     }
 }
 
-// start LoRa receiver (time=LMIC.rxtime, timeout=LMIC.rxsyms, result=LMIC.frame[LMIC.dataLen])
+// start LoRa receiver (time=LMIC.radio.rxtime, timeout=LMIC.radio.rxsyms, result=LMIC.radio.pFrame[LMIC.radio.dataLen])
 // Chapter 14.3: Circuit configuration for basic rx operation
 static void rxlora(u1_t rxmode) {
     // Send configuration commands to radio
@@ -981,7 +981,7 @@ static void rxlora(u1_t rxmode) {
 
     // now instruct the radio to receive
     if (rxmode == RXMODE_SINGLE) {
-        u4_t nLate = lmic_hal_waitUntil(LMIC.rxtime);
+        u4_t nLate = lmic_hal_waitUntil(LMIC.radio.rxtime);
         u1_t rxTimeoutSingle[SX126X_TIMEOUT_LEN] = {
             0x00,
             0x00,
@@ -992,7 +992,7 @@ static void rxlora(u1_t rxmode) {
         rxlate(nLate);
 #if LMIC_DEBUG_LEVEL > 0
         ostime_t now = os_getTime();
-        LMIC_DEBUG_PRINTF("start single rx: now-rxtime: %"LMIC_PRId_ostime_t"\n", now - LMIC.rxtime);
+        LMIC_DEBUG_PRINTF("start single rx: now-rxtime: %"LMIC_PRId_ostime_t"\n", now - LMIC.radio.rxtime);
 #endif
     } else {
         LMICOS_logEventUint32("+Rx LoRa Continuous", rxmode);
@@ -1052,7 +1052,7 @@ static void rxfsk(u1_t rxmode) {
 
     // now instruct the radio to receive
     if (rxmode == RXMODE_SINGLE) {
-        u4_t nLate = lmic_hal_waitUntil(LMIC.rxtime); // busy wait until exact rx time
+        u4_t nLate = lmic_hal_waitUntil(LMIC.radio.rxtime); // busy wait until exact rx time
         u1_t rxTimeoutSingle[SX126X_TIMEOUT_LEN] = {
             0x00,
             0x00,
@@ -1466,7 +1466,7 @@ void os_radio(u1_t mode) {
     // populate LMIC.radio fields from LMIC for compatibility
     LMIC.radio.freq = LMIC.freq;
     LMIC.radio.pFrame = LMIC.frame;
-    LMIC.radio.rxtime = LMIC.rxtime;
+    LMIC.radio.rxtime = LMIC.nextRxTime;
     LMIC.radio.rps = LMIC.rps;
     LMIC.radio.rxsyms = LMIC.rxsyms;
     LMIC.radio.dataLen = LMIC.dataLen;


### PR DESCRIPTION
Rebased version of #1053 from @PontusO with version bump.

## Summary
- Fix `os_radio()` to populate `LMIC.radio.rxtime` from `LMIC.nextRxTime` (not stale `LMIC.rxtime`)
- Update `rxlora()` and `rxfsk()` to use `LMIC.radio.rxtime` consistently
- Bump version to 6.0.2-pre2

## Background
v6.0.0 renamed `LMIC.rxtime` to `LMIC.nextRxTime` but the SX126x driver was not updated. The SX127x driver was updated correctly. This caused all SX126x RX windows to be mistimed.

Original PR: #1053 by @PontusO

🤖 Generated with [Claude Code](https://claude.com/claude-code)