### PR TITLE
Fix uninitialized loop variable in SX126x setRx() (fixes #1052)

### DIFF
--- a/src/lmic/lmic.h
+++ b/src/lmic/lmic.h
@@ -106,7 +106,7 @@ extern "C"{
 	((((major)*UINT32_C(1)) << 24) | (((minor)*UINT32_C(1)) << 16) | (((patch)*UINT32_C(1)) << 8) | (((local)*UINT32_C(1)) << 0))
 
 #define	ARDUINO_LMIC_VERSION    \
-    ARDUINO_LMIC_VERSION_CALC(6, 0, 2, 2)  /* 6.0.2-pre2 */
+    ARDUINO_LMIC_VERSION_CALC(6, 0, 2, 3)  /* 6.0.2-pre3 */
 
 #define	ARDUINO_LMIC_VERSION_GET_MAJOR(v)	\
 	((((v)*UINT32_C(1)) >> 24u) & 0xFFu)

--- a/src/lmic/radio_sx126x.c
+++ b/src/lmic/radio_sx126x.c
@@ -336,7 +336,7 @@ static void setRx(u1_t timeout[SX126X_TIMEOUT_LEN]) {
     // It is advised to add the following commands after ANY Rx with Timeout active sequence,
     // which stop the RTC and clear the timeout event, if any.
     u1_t hasTimeout = 0;
-    for (u1_t i; i < SX126X_TIMEOUT_LEN; i++) {
+    for (u1_t i = 0; i < SX126X_TIMEOUT_LEN; i++) {
         if ((timeout[i] != 0x00) && (timeout[i] !=0xFF)) {
             hasTimeout = 1;
             break;


### PR DESCRIPTION
Rebased version of #1052 from @PontusO with version bump.

## Summary
- Initialize loop variable `i` in `setRx()` workaround 15.3 timeout detection
- Bump version to 6.0.2-pre3

## Background
`u1_t i;` without initialization is undefined behavior. The workaround 15.3 RTC clearing logic was unreliable as a result.

See also #1059, #1060, #1061 for follow-up refactoring and style issues in this area.

Original PR: #1052 by @PontusO

🤖 Generated with [Claude Code](https://claude.com/claude-code)