### PR TITLE
Fix SX126x DIO2 RF switch check treating function as pointer

### DIFF
--- a/src/lmic/lmic.h
+++ b/src/lmic/lmic.h
@@ -106,7 +106,7 @@ extern "C"{
 	((((major)*UINT32_C(1)) << 24) | (((minor)*UINT32_C(1)) << 16) | (((patch)*UINT32_C(1)) << 8) | (((local)*UINT32_C(1)) << 0))
 
 #define	ARDUINO_LMIC_VERSION    \
-    ARDUINO_LMIC_VERSION_CALC(6, 0, 2, 3)  /* 6.0.2-pre3 */
+    ARDUINO_LMIC_VERSION_CALC(6, 0, 2, 4)  /* 6.0.2-pre4 */
 
 #define	ARDUINO_LMIC_VERSION_GET_MAJOR(v)	\
 	((((v)*UINT32_C(1)) >> 24u) & 0xFFu)

--- a/src/lmic/radio_sx126x.c
+++ b/src/lmic/radio_sx126x.c
@@ -774,7 +774,7 @@ void radio_config(void) {
     }
 
     // If the board has RfSwitch, switch on
-    if (lmic_hal_queryUsingDIO2AsRfSwitch) {
+    if (lmic_hal_queryUsingDIO2AsRfSwitch()) {
         setDio2AsRfSwitchCtrl();
     }
 


### PR DESCRIPTION
Rebased version of #1051 from @PontusO with version bump.

## Summary
- Add missing `()` to `lmic_hal_queryUsingDIO2AsRfSwitch` call in `radio_config()`
- Bump version to 6.0.2-pre4

## Background
Without the parentheses, the expression evaluates the function pointer (always non-null/true) instead of calling the function. DIO2 was always configured as RF switch regardless of the HAL configuration. Boards that use DIO2 as RF switch were unaffected; boards that don't got incorrect DIO2 configuration.

This bug has existed since the SX126x driver was first added.

Original PR: #1051 by @PontusO

🤖 Generated with [Claude Code](https://claude.com/claude-code)