### PR TITLE
Fix SE driver dispatch for non-default secure element drivers

### DIFF
--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -1580,7 +1580,7 @@ static bit_t processJoinAccept (void) {
 
     LMIC_SecureElement_Error_t seErr;
 
-    seErr = LMIC_SecureElement_Default_decodeJoinAccept(
+    seErr = LMIC_SecureElement_decodeJoinAccept(
         LMIC.frame, dlen,
         LMIC.frame,
         LMIC_SecureElement_JoinFormat_JoinRequest10

--- a/src/lmic/lmic.h
+++ b/src/lmic/lmic.h
@@ -106,7 +106,7 @@ extern "C"{
 	((((major)*UINT32_C(1)) << 24) | (((minor)*UINT32_C(1)) << 16) | (((patch)*UINT32_C(1)) << 8) | (((local)*UINT32_C(1)) << 0))
 
 #define	ARDUINO_LMIC_VERSION    \
-    ARDUINO_LMIC_VERSION_CALC(6, 0, 2, 4)  /* 6.0.2-pre4 */
+    ARDUINO_LMIC_VERSION_CALC(6, 0, 2, 5)  /* 6.0.2-pre5 */
 
 #define	ARDUINO_LMIC_VERSION_GET_MAJOR(v)	\
 	((((v)*UINT32_C(1)) >> 24u) & 0xFFu)

--- a/src/se/i/lmic_secure_element_api.h
+++ b/src/se/i/lmic_secure_element_api.h
@@ -159,7 +159,7 @@ LMIC_SecureElement_aes128Encrypt_t LMIC_SecureElement_aes128Encrypt;
 	LMIC_SecureElement_METHOD_(a_driver, a_fn)
 
 /// \cond FALSE
-LMIC_SecureElement_DECLARE_DRIVER_FNS(Default);
+LMIC_SecureElement_DECLARE_DRIVER_FNS(LMIC_CFG_SecureElement_DRIVER);
 /// \endcond
 
 /// \copydoc LMIC_SecureElement_initialize_t

--- a/src/se/i/lmic_secure_element_interface.h
+++ b/src/se/i/lmic_secure_element_interface.h
@@ -494,7 +494,20 @@ LMIC_SecureElement_aes128Encrypt_t(const uint8_t *pKey, const uint8_t *pInput, u
 ///
 /// \hideinitializer
 ///
-#define LMIC_SecureElement_DECLARE_DRIVER_FNS(a_driver)										 \
+#define LMIC_SecureElement_DECLARE_DRIVER_FNS(a_driver)	\
+	LMIC_SecureElement_DECLARE_DRIVER_FNS_(a_driver)
+
+/// \brief Declare all driver functions for a given driver name (inner macro).
+///
+/// \details
+///	This macro does the actual token-pasting. It is called by
+///	LMIC_SecureElement_DECLARE_DRIVER_FNS(), which forces macro-expansion
+///	of its argument first, following the same two-level pattern as
+///	LMIC_SecureElement_METHOD() / LMIC_SecureElement_METHOD_().
+///
+/// \hideinitializer
+///
+#define LMIC_SecureElement_DECLARE_DRIVER_FNS_(a_driver)									 \
 	LMIC_SecureElement_initialize_t LMIC_SecureElement_##a_driver##_initialize;				 \
 	LMIC_SecureElement_getRandomU1_t LMIC_SecureElement_##a_driver##_getRandomU1;			   \
 	LMIC_SecureElement_getRandomU2_t LMIC_SecureElement_##a_driver##_getRandomU2;			   \


### PR DESCRIPTION
Reworked version of #1057 from @PontusO.

## Summary
- Add two-level macro indirection to `LMIC_SecureElement_DECLARE_DRIVER_FNS()` in the interface header, matching the existing `METHOD`/`METHOD_` pattern
- Use `LMIC_CFG_SecureElement_DRIVER` instead of hardcoded `Default` in the API header declaration
- Fix `processJoinAccept()` in `lmic.c` to use the dispatch wrapper instead of hardcoding `_Default_`
- Bump version to 6.0.2-pre5

## Background
The original `DECLARE_DRIVER_FNS` macro used `##` token-pasting directly, so passing `LMIC_CFG_SecureElement_DRIVER` pasted the macro name literally instead of expanding it first. This meant only the Default driver's functions were declared, and non-default SE drivers could not compile.

Separately, `lmic.c` bypassed the dispatch layer entirely by calling `LMIC_SecureElement_Default_decodeJoinAccept()` directly.

Reworked from #1057 to put the two-level indirection in the interface header (where the macro is defined) rather than adding a separate wrapper macro in the API header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)