### PR TITLE
Add board-configurable SX126x crystal oscillator trim support

### DIFF
--- a/doc/HOWTO-Manually-Configure.md
+++ b/doc/HOWTO-Manually-Configure.md
@@ -257,6 +257,8 @@ public:
 
 - `queryUsingDIO3AsTCXOSwitch(void)` shall return true when a SX126x transceiver is physically configured with DIO3 driving an external temperature controlled crystal oscillator (TXCO).
 
+- `querySX126xXTATrim(void)` and `querySX126xXTBTrim(void)` return the crystal oscillator trim capacitance values for the SX126x XTA and XTB pins (registers 0x0911 and 0x0912). Valid trim values are 0x00 through 0x3F; the chip reset default is 0x05 for both. Return `kSX126xXtalTrimUseDefault` (0xFF) to leave the chip reset value untouched (this is the default). Some board designs require different trim values for adequate frequency accuracy.
+
 Caution: the LMIC has no way of knowing whether the mode you return makes sense. Use of 20 dBm mode without limiting duty cycle can over-stress your module. The LMIC currently does not have any code to duty-cycle US transmissions at 20 dBm. If properly limiting transmissions to 400 milliseconds, a 1% duty-cycle means at most one message every 40 seconds. This shouldn't be a problem in practice, but buggy upper level software still might do things more rapidly.
 
 <!-- there are links to the following section, so be careful when renaming -->

--- a/src/arduino_lmic_hal_configuration.h
+++ b/src/arduino_lmic_hal_configuration.h
@@ -20,7 +20,6 @@ Author:
 
 #include <stdint.h>
 #include "lmic/lmic_env.h"
-#include "lmic/hal.h"
 
 namespace Arduino_LMIC {
 
@@ -99,9 +98,10 @@ public:
 
 	// SX126x crystal oscillator trim (registers XTATrim/XTBTrim, 0x0911/0x0912).
 	// Valid trim values are 0x00-0x3F; chip reset default is 0x05 for both.
-	// Return LMIC_HAL_SX126X_XTAL_TRIM_USE_DEFAULT (0xFF) to leave the chip reset value untouched.
-	virtual uint8_t querySX126xXTATrim(void) { return LMIC_HAL_SX126X_XTAL_TRIM_USE_DEFAULT; }
-	virtual uint8_t querySX126xXTBTrim(void) { return LMIC_HAL_SX126X_XTAL_TRIM_USE_DEFAULT; }
+	// Return kSX126xXtalTrimUseDefault to leave the chip reset value untouched.
+	static constexpr uint8_t kSX126xXtalTrimUseDefault = 0xFF;
+	virtual uint8_t querySX126xXTATrim(void) { return kSX126xXtalTrimUseDefault; }
+	virtual uint8_t querySX126xXTBTrim(void) { return kSX126xXtalTrimUseDefault; }
 
 	// compute desired transmit power policy.  HopeRF needs
 	// (and previous versions of this library always chose)

--- a/src/arduino_lmic_hal_configuration.h
+++ b/src/arduino_lmic_hal_configuration.h
@@ -20,6 +20,7 @@ Author:
 
 #include <stdint.h>
 #include "lmic/lmic_env.h"
+#include "lmic/hal.h"
 
 namespace Arduino_LMIC {
 
@@ -95,6 +96,12 @@ public:
 	virtual bool queryUsingDcdc(void) { return false; }
 	virtual bool queryUsingDIO2AsRfSwitch(void) { return false; }
 	virtual bool queryUsingDIO3AsTCXOSwitch(void) { return false; }
+
+	// SX126x crystal oscillator trim (registers XTATrim/XTBTrim, 0x0911/0x0912).
+	// Valid trim values are 0x00-0x3F; chip reset default is 0x05 for both.
+	// Return LMIC_HAL_SX126X_XTAL_TRIM_USE_DEFAULT (0xFF) to leave the chip reset value untouched.
+	virtual uint8_t querySX126xXTATrim(void) { return LMIC_HAL_SX126X_XTAL_TRIM_USE_DEFAULT; }
+	virtual uint8_t querySX126xXTBTrim(void) { return LMIC_HAL_SX126X_XTAL_TRIM_USE_DEFAULT; }
 
 	// compute desired transmit power policy.  HopeRF needs
 	// (and previous versions of this library always chose)

--- a/src/hal/hal.cpp
+++ b/src/hal/hal.cpp
@@ -570,6 +570,12 @@ bit_t lmic_hal_queryUsingDIO3AsTCXOSwitch(void) {
     return pHalConfig->queryUsingDIO3AsTCXOSwitch();
 }
 
+// Verify C++ and C sentinel values for SX126x crystal trim match.
+static_assert(
+    Arduino_LMIC::HalConfiguration_t::kSX126xXtalTrimUseDefault == LMIC_HAL_SX126X_XTAL_TRIM_USE_DEFAULT,
+    "C++ and C sentinel values for SX126x crystal trim must match"
+    );
+
 uint8_t lmic_hal_querySX126xXTATrim(void) {
     return pHalConfig->querySX126xXTATrim();
 }

--- a/src/hal/hal.cpp
+++ b/src/hal/hal.cpp
@@ -570,6 +570,14 @@ bit_t lmic_hal_queryUsingDIO3AsTCXOSwitch(void) {
     return pHalConfig->queryUsingDIO3AsTCXOSwitch();
 }
 
+uint8_t lmic_hal_querySX126xXTATrim(void) {
+    return pHalConfig->querySX126xXTATrim();
+}
+
+uint8_t lmic_hal_querySX126xXTBTrim(void) {
+    return pHalConfig->querySX126xXTBTrim();
+}
+
 uint8_t lmic_hal_getTxPowerPolicy(
     u1_t inputPolicy,
     s1_t requestedPower,

--- a/src/lmic/hal.h
+++ b/src/lmic/hal.h
@@ -171,6 +171,18 @@ bit_t lmic_hal_queryUsingDIO2AsRfSwitch(void);
 /* SX126x function: find out if the board is configured to control a TCXO with modem DIO3 */
 bit_t lmic_hal_queryUsingDIO3AsTCXOSwitch(void);
 
+/* Sentinel returned by lmic_hal_querySX126xXTATrim/XTBTrim when the board
+   does not specify a trim value and the chip reset default should be used. */
+#define LMIC_HAL_SX126X_XTAL_TRIM_USE_DEFAULT  ((uint8_t) 0xFF)
+
+/* SX126x function: get XTA crystal trim value (0x00-0x3F), or
+   LMIC_HAL_SX126X_XTAL_TRIM_USE_DEFAULT to leave chip reset value unchanged */
+uint8_t lmic_hal_querySX126xXTATrim(void);
+
+/* SX126x function: get XTB crystal trim value (0x00-0x3F), or
+   LMIC_HAL_SX126X_XTAL_TRIM_USE_DEFAULT to leave chip reset value unchanged */
+uint8_t lmic_hal_querySX126xXTBTrim(void);
+
 /* represent the various radio TX power policy */
 enum	{
 	LMICHAL_radio_tx_power_policy_rfo	= 0,

--- a/src/lmic/hal.h
+++ b/src/lmic/hal.h
@@ -173,7 +173,7 @@ bit_t lmic_hal_queryUsingDIO3AsTCXOSwitch(void);
 
 /* Sentinel returned by lmic_hal_querySX126xXTATrim/XTBTrim when the board
    does not specify a trim value and the chip reset default should be used. */
-#define LMIC_HAL_SX126X_XTAL_TRIM_USE_DEFAULT  ((uint8_t) 0xFF)
+#define LMIC_HAL_SX126X_XTAL_TRIM_USE_DEFAULT  UINT8_C(0xFF)
 
 /* SX126x function: get XTA crystal trim value (0x00-0x3F), or
    LMIC_HAL_SX126X_XTAL_TRIM_USE_DEFAULT to leave chip reset value unchanged */

--- a/src/lmic/lmic.h
+++ b/src/lmic/lmic.h
@@ -106,7 +106,7 @@ extern "C"{
 	((((major)*UINT32_C(1)) << 24) | (((minor)*UINT32_C(1)) << 16) | (((patch)*UINT32_C(1)) << 8) | (((local)*UINT32_C(1)) << 0))
 
 #define	ARDUINO_LMIC_VERSION    \
-    ARDUINO_LMIC_VERSION_CALC(6, 0, 2, 5)  /* 6.0.2-pre5 */
+    ARDUINO_LMIC_VERSION_CALC(6, 1, 0, 1)  /* 6.1.0-pre1 */
 
 #define	ARDUINO_LMIC_VERSION_GET_MAJOR(v)	\
 	((((v)*UINT32_C(1)) >> 24u) & 0xFFu)

--- a/src/lmic/radio_sx126x.c
+++ b/src/lmic/radio_sx126x.c
@@ -785,14 +785,12 @@ void radio_config(void) {
     // Apply board-specific crystal oscillator trim values if configured.
     // Some board designs require different XTA/XTB trim capacitance than the
     // chip reset default (0x05) for adequate frequency accuracy.
-    {
-        uint8_t xta = lmic_hal_querySX126xXTATrim();
-        uint8_t xtb = lmic_hal_querySX126xXTBTrim();
-        if (xta != LMIC_HAL_SX126X_XTAL_TRIM_USE_DEFAULT)
-            writeRegister(XTATrim, xta);
-        if (xtb != LMIC_HAL_SX126X_XTAL_TRIM_USE_DEFAULT)
-            writeRegister(XTBTrim, xtb);
-    }
+    uint8_t xta = lmic_hal_querySX126xXTATrim();
+    uint8_t xtb = lmic_hal_querySX126xXTBTrim();
+    if (xta != LMIC_HAL_SX126X_XTAL_TRIM_USE_DEFAULT)
+        writeRegister(XTATrim, xta);
+    if (xtb != LMIC_HAL_SX126X_XTAL_TRIM_USE_DEFAULT)
+        writeRegister(XTBTrim, xtb);
 
     // DC-DC regulator is hardware dependent
     if (lmic_hal_queryUsingDcdc()) {

--- a/src/lmic/radio_sx126x.c
+++ b/src/lmic/radio_sx126x.c
@@ -782,6 +782,18 @@ void radio_config(void) {
     // This register modification must be done after a Power On Reset, or a wake-up from cold Start.
     writeRegister(TxClampConfig, (readRegister(TxClampConfig) | 0x1E));
 
+    // Apply board-specific crystal oscillator trim values if configured.
+    // Some board designs require different XTA/XTB trim capacitance than the
+    // chip reset default (0x05) for adequate frequency accuracy.
+    {
+        uint8_t xta = lmic_hal_querySX126xXTATrim();
+        uint8_t xtb = lmic_hal_querySX126xXTBTrim();
+        if (xta != LMIC_HAL_SX126X_XTAL_TRIM_USE_DEFAULT)
+            writeRegister(XTATrim, xta);
+        if (xtb != LMIC_HAL_SX126X_XTAL_TRIM_USE_DEFAULT)
+            writeRegister(XTBTrim, xtb);
+    }
+
     // DC-DC regulator is hardware dependent
     if (lmic_hal_queryUsingDcdc()) {
         setRegulatorMode(0x01);


### PR DESCRIPTION
Reworked version of #1054 from @PontusO.

## Summary
- Add `querySX126xXTATrim()` and `querySX126xXTBTrim()` virtual methods to `HalConfiguration_t`
- Default returns `kSX126xXtalTrimUseDefault` (0xFF), leaving chip reset values untouched
- C sentinel (`LMIC_HAL_SX126X_XTAL_TRIM_USE_DEFAULT` in `hal.h`) uses `UINT8_C(0xFF)`
- `static_assert` in `hal.cpp` verifies C++ and C sentinels match
- Document new methods in `doc/HOWTO-Manually-Configure.md`
- Bump version to 6.1.0-pre1

## Changes from original PR
- Removed `#include "lmic/hal.h"` from `arduino_lmic_hal_configuration.h` to avoid namespace pollution
- C++ sentinel is `static constexpr` on the class; default virtual methods are inline using it
- Used `UINT8_C()` instead of cast in C `#define`
- Added `static_assert` to verify C/C++ sentinel agreement
- Added documentation

## Background
Some SX126x board designs need different XTA/XTB crystal trim capacitance than the chip reset default (0x05) for adequate frequency accuracy. Board files override the methods:
```cpp
virtual uint8_t querySX126xXTATrim(void) override { return 0x12; }
virtual uint8_t querySX126xXTBTrim(void) override { return 0x12; }
```

See also #1067 for longer-term architecture discussion about radio-specific configuration.

Original PR: #1054 by @PontusO

🤖 Generated with [Claude Code](https://claude.com/claude-code)